### PR TITLE
Fix deploy workflow: replace deprecated GoogleCloudPlatform action

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -21,13 +21,16 @@ jobs:
           - Notify
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
         with:
-          version: "286.0.0"
-          service_account_email: ${{ secrets.SERVICE_ACCOUNT_EMAIL }}
-          service_account_key: ${{ secrets.SERVICE_ACCOUNT_KEY }}
+          credentials_json: ${{ secrets.SERVICE_ACCOUNT_KEY }}
+      - uses: google-github-actions/setup-gcloud@v2
+        with:
           project_id: ${{ secrets.PROJECT_ID }}
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.21"
       - run: go mod vendor
       - name: Deploy ${{ matrix.function }}
         run: ./scripts/deploy-function.sh ${{ matrix.function }}


### PR DESCRIPTION
PR #2 マージ後の Deploy Functions ワークフローが、削除された旧 action `GoogleCloudPlatform/github-actions/setup-gcloud@master` を参照していて失敗しています ([失敗 run](https://github.com/ngs/onairlog-sync/actions/runs/25512129959))。

## 変更点

- `GoogleCloudPlatform/github-actions/setup-gcloud@master` → `google-github-actions/auth@v2` + `google-github-actions/setup-gcloud@v2`
- `actions/checkout@v2` → `@v4`
- 認証キー (`SERVICE_ACCOUNT_KEY` シークレット) は新 action の `credentials_json` 入力に渡す
- `actions/setup-go@v5` で Go 1.21 を明示 (`go.mod` に合わせる)

## 注意

`SERVICE_ACCOUNT_KEY` シークレットは **JSON キー全文** を保持している前提です (旧 action もそうだった)。問題なければそのまま動きます。

## Test plan

- [ ] マージ後、Deploy Functions ワークフローが成功する
- [ ] `gcloud functions describe Sync` で `runtime=go121`, `FIRESTORE_DATABASE=onairlog`, `DATABASE_URI` が消えていることを確認