### PR TITLE
Migrate Cloud Functions to Gen 2 (Go runtime no longer on Gen 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,32 @@ J-WAVE の OnAir Log をクロールして Firestore に保存し、新着曲を
 
 ## ローカル実行
 
+Cloud Functions Gen 2 では 1 プロセスで 1 関数のみ動かします。`FUNCTION_TARGET` で対象を切り替えてください。
+
 ```sh
 gcloud auth application-default login
 
-go run ./local
+# Sync をローカルで起動
+FUNCTION_TARGET=Sync PROJECT_ID=onairlog FIRESTORE_DATABASE=onairlog go run ./local
 
-# 別ターミナル
-curl http://localhost:8080/sync -d '{"data":""}'
+# 別ターミナルから CloudEvent を投げる
+curl -X POST http://localhost:8080 \
+  -H "Content-Type: application/json" \
+  -H "ce-id: 1" -H "ce-source: //pubsub.googleapis.com/" \
+  -H "ce-specversion: 1.0" \
+  -H "ce-type: google.cloud.pubsub.topic.v1.messagePublished" \
+  -d '{"message":{"data":""},"subscription":"projects/onairlog/subscriptions/sync"}'
+
+# Notify を試す場合
+FUNCTION_TARGET=Notify PROJECT_ID=onairlog FIRESTORE_DATABASE=onairlog \
+  SLACK_WEBHOOK_URL=https://... go run ./local
 JSON=$(cat fixtures/songs.json)
-curl http://localhost:8080/notify -d "{\"data\":\"$(echo $JSON | base64)\"}"
+curl -X POST http://localhost:8080 \
+  -H "Content-Type: application/json" \
+  -H "ce-id: 1" -H "ce-source: //pubsub.googleapis.com/" \
+  -H "ce-specversion: 1.0" \
+  -H "ce-type: google.cloud.pubsub.topic.v1.messagePublished" \
+  -d "{\"message\":{\"data\":\"$(echo -n $JSON | base64)\"},\"subscription\":\"projects/onairlog/subscriptions/notify\"}"
 ```
 
 ## Firestore 初期セットアップ

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	cloud.google.com/go/pubsub v1.33.0
 	github.com/GoogleCloudPlatform/functions-framework-go v1.8.1
 	github.com/ashwanthkumar/slack-go-webhook v0.0.0-20200209025033-430dd4e66960
+	github.com/cloudevents/sdk-go/v2 v2.14.0
 	github.com/gocolly/colly v1.2.0
 	google.golang.org/api v0.149.0
 	google.golang.org/grpc v1.59.0
@@ -25,7 +26,6 @@ require (
 	github.com/antchfx/htmlquery v1.3.6 // indirect
 	github.com/antchfx/xmlquery v1.5.1 // indirect
 	github.com/antchfx/xpath v1.3.6 // indirect
-	github.com/cloudevents/sdk-go/v2 v2.14.0 // indirect
 	github.com/elazarl/goproxy v1.8.3 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/local/main.go
+++ b/local/main.go
@@ -5,12 +5,10 @@ import (
 	"os"
 
 	"github.com/GoogleCloudPlatform/functions-framework-go/funcframework"
-	app "github.com/ngs/onairlog-sync"
+	_ "github.com/ngs/onairlog-sync"
 )
 
 func main() {
-	funcframework.RegisterEventFunction("/sync", app.Sync)
-	funcframework.RegisterEventFunction("/notify", app.Notify)
 	port := "8080"
 	if envPort := os.Getenv("PORT"); envPort != "" {
 		port = envPort

--- a/notify.go
+++ b/notify.go
@@ -5,15 +5,26 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
 	"github.com/ashwanthkumar/slack-go-webhook"
+	"github.com/cloudevents/sdk-go/v2/event"
 )
 
-func Notify(ctx context.Context, m PubSubMessage) error {
-	var songs []Song
+func init() {
+	functions.CloudEvent("Notify", Notify)
+}
+
+func Notify(ctx context.Context, e event.Event) error {
 	webhookUrl := mustGetenv("SLACK_WEBHOOK_URL")
 	app := NewApp(ctx)
-	err := json.Unmarshal(m.Data, &songs)
-	if err != nil {
+
+	var msg PubSubMessage
+	if err := e.DataAs(&msg); err != nil {
+		app.LogError(err)
+		return err
+	}
+	var songs []Song
+	if err := json.Unmarshal(msg.Message.Data, &songs); err != nil {
 		app.LogError(err)
 		return err
 	}

--- a/pub_sub_message.go
+++ b/pub_sub_message.go
@@ -1,6 +1,12 @@
 package onairlogsync
 
-// PubSubMessage is the payload of a Pub/Sub event.
+// PubSubMessage is the Pub/Sub payload nested inside a Cloud Functions Gen 2
+// CloudEvent of type google.cloud.pubsub.topic.v1.messagePublished. The
+// CloudEvent's Data() is JSON of the form {"message": {"data": "<base64>"},
+// "subscription": "..."}.
 type PubSubMessage struct {
-	Data []byte `json:"data"`
+	Message struct {
+		Data []byte `json:"data"`
+	} `json:"message"`
+	Subscription string `json:"subscription"`
 }

--- a/scripts/deploy-function.sh
+++ b/scripts/deploy-function.sh
@@ -3,6 +3,7 @@
 set -eux
 
 RUNTIME=go126
+REGION=${REGION:-us-central1}
 BASE_DIR=$(cd $(dirname $0)/.. && pwd)
 FUNCTION=$1
 
@@ -17,7 +18,11 @@ EOF
 TOPIC=$(echo $FUNCTION | sed 's/\([a-z0-9]\)\([A-Z]\)/\1-\2/g' | tr '[:upper:]' '[:lower:]')
 
 gcloud functions deploy $FUNCTION \
+    --gen2 \
+    --region $REGION \
     --trigger-topic $TOPIC \
     --runtime $RUNTIME \
+    --entry-point $FUNCTION \
+    --source . \
     --service-account $SERVICE_ACCOUNT_EMAIL \
     --env-vars-file "${BASE_DIR}/.env.yml"

--- a/sync.go
+++ b/sync.go
@@ -4,9 +4,16 @@ import (
 	"context"
 	"fmt"
 	"log"
+
+	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
+	"github.com/cloudevents/sdk-go/v2/event"
 )
 
-func Sync(ctx context.Context, m PubSubMessage) error {
+func init() {
+	functions.CloudEvent("Sync", Sync)
+}
+
+func Sync(ctx context.Context, e event.Event) error {
 	app := NewApp(ctx)
 	defer app.Close()
 	last := app.LastSong()


### PR DESCRIPTION
go126 にアップグレードしたところ、Deploy Functions ワークフローが以下のエラーで失敗しました ([失敗 run](https://github.com/ngs/onairlog-sync/actions/runs/25512129959)):

\`\`\`
ERROR: argument --runtime: go126 is not a supported runtime on GCF 1st gen
\`\`\`

\`gcloud functions runtimes list\` を確認すると、**Cloud Functions 1st gen で利用可能な Go ランタイムは現在 0 個** (\`go122\` 以降はすべて 2nd gen 専用) で、1st gen での Go デプロイは事実上廃止されています。

## 変更点

- **\`sync.go\` / \`notify.go\`**: シグネチャを \`PubSubMessage\` から \`cloudevents/sdk-go\` の \`event.Event\` に変更。\`functions.CloudEvent\` で登録する \`init()\` を追加。
- **\`pub_sub_message.go\`**: Gen 2 の CloudEvent エンベロープに合わせ \`{"message":{"data":...}}\` 構造に変更。
- **\`local/main.go\`**: 手動 \`RegisterEventFunction\` を撤去。\`init()\` 登録と \`FUNCTION_TARGET\` 環境変数で対象を切り替える Gen 2 セマンティクスに合わせる (1 プロセス 1 関数)。
- **\`scripts/deploy-function.sh\`**: \`--gen2\`, \`--region\`, \`--entry-point\`, \`--source\` を追加。
- **README**: ローカル実行手順を CloudEvent 形式に更新。

## マージ後にユーザー側で必要な作業

なし。デプロイ用 SA (\`onairlog@onairlog.iam.gserviceaccount.com\`) は \`run.admin\`, \`cloudfunctions.admin\`, \`iam.serviceAccountUser\` を既に保持しているため Gen 2 デプロイに必要な権限は揃っています。

## Test plan

- [ ] \`go build ./...\` / \`go vet ./...\` (確認済み)
- [ ] マージ後、Deploy Functions ワークフローが Sync / Notify 両方で成功
- [ ] \`gcloud functions describe Sync --gen2 --region=us-central1\` で 2nd gen として配置されている
- [ ] 1 〜 2 時間後に Slack に新着曲通知が届く