### PR TITLE
Split airplays into plays + canonical songs (normalization layer)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - master
+      - ci
+  pull_request:
+
+jobs:
+  test:
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: .go-version
+
+      - name: Vet (root module)
+        run: go vet ./...
+      - name: Test (root module)
+        run: go test -v ./...
+
+      - name: Vet (migrate module)
+        working-directory: migrate
+        run: go vet ./...
+      - name: Build (migrate module)
+        working-directory: migrate
+        run: go build ./...

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 coverage.html
 coverage.txt
 vendor
+/migrate/migrate

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 J-WAVE の OnAir Log をクロールして Firestore に保存し、新着曲を Slack 通知する Cloud Functions。
 
+## データモデル
+
+- `songs/{songId}`: 楽曲マスター。`(title, artist)` を正規化して同一曲を 1 ドキュメントに集約。`firstAired` / `lastAired` / `playCount` を保持。
+- `plays/{playId}`: オンエア履歴。各 doc は `songId` で `songs` を参照。`rawTitle` / `rawArtist` には原文を保存。
+
+ID は決定論的: `songId = sha1(normTitle | normArtist)`、`playId = sha1(unix_time | songId)`。同じ曲・同じ時刻のエントリは冪等に書き換えられる。
+
 ## 環境変数
 
 | 変数 | 用途 |
@@ -58,7 +65,7 @@ curl -X POST http://localhost:8080 \
 
 ## Cloud SQL からのデータ移行
 
-`migrate/` 以下に MySQL → Firestore の一括移行ツールがあります。
+`migrate/` 以下に MySQL → Firestore の一括移行ツールがあります。MySQL の各行を `plays` に書き、メモリ上で集計した楽曲メタを `songs` に書き出します。
 
 ```sh
 cd migrate
@@ -73,8 +80,11 @@ go run .
 # 中断時の再開 (出力末尾の lastID から)
 go run . --start-id=123456
 
-# 動作確認
+# 動作確認 (Firestore に書き込まずに正規化結果と件数を見る)
 go run . --limit=100 --dry-run
+
+# songs / plays を全消去
+go run . --reset
 ```
 
-ドキュメント ID は `sha1(unix_time | title | artist)` で決定論的に生成されるため、再実行は冪等です。
+ID 生成が決定論的なので、再実行は冪等です。同じ曲が同じ時刻に重複登録されることはありません。

--- a/README.md
+++ b/README.md
@@ -65,26 +65,51 @@ curl -X POST http://localhost:8080 \
 
 ## Cloud SQL からのデータ移行
 
-`migrate/` 以下に MySQL → Firestore の一括移行ツールがあります。MySQL の各行を `plays` に書き、メモリ上で集計した楽曲メタを `songs` に書き出します。
+`migrate/` 以下に MySQL → Firestore の一括移行ツールがあります。**集計を MySQL に任せて Firestore に流す 2 段構成**で、メモリ使用量を一定に保ちつつ各フェーズが独立に再開できます。
+
+### Phase 1: 既存 raw `songs` から MySQL 上に `csongs` / `plays` を構築
+
+正規化と aggregation を MySQL の `INSERT ... ON DUPLICATE KEY UPDATE` で行います。
 
 ```sh
 cd migrate
 export DATABASE_URI='user:pass@tcp(host:3306)/dbname'
-export PROJECT_ID='your-project-id'
-export FIRESTORE_DATABASE='onairlog'
 gcloud auth application-default login
 
-# 全件移行
-go run .
+# 全件 prep
+go run . --prep
 
-# 中断時の再開 (出力末尾の lastID から)
-go run . --start-id=123456
+# 再開 (raw songs.id ベース)
+go run . --prep --start-id=1234567
 
-# 動作確認 (Firestore に書き込まずに正規化結果と件数を見る)
-go run . --limit=100 --dry-run
-
-# songs / plays を全消去
-go run . --reset
+# ドライラン
+go run . --prep --limit=100 --dry-run
 ```
 
-ID 生成が決定論的なので、再実行は冪等です。同じ曲が同じ時刻に重複登録されることはありません。
+完了後、SQL で内容確認:
+
+```sql
+SELECT COUNT(*) FROM csongs;
+SELECT COUNT(*) FROM plays;
+SELECT title, artist, play_count FROM csongs ORDER BY play_count DESC LIMIT 50;
+```
+
+### Phase 2: MySQL から Firestore へ流し込み
+
+```sh
+export PROJECT_ID='your-project-id'
+export FIRESTORE_DATABASE='onairlog'
+
+# 全 plays + csongs を Firestore に投入
+go run .
+
+# plays だけ途中再開
+go run . --start-play-id=<lastID>
+
+# csongs だけ途中再開
+go run . --start-song-id=<lastID>
+```
+
+Firestore 側を全消去する場合: `go run . --reset`
+
+ID は決定論的に生成されるため、再実行は冪等です。

--- a/app.go
+++ b/app.go
@@ -112,11 +112,14 @@ func (app *App) LastPlay() *Play {
 	return &play
 }
 
-// PlayDocID returns the deterministic Firestore ID for a Play given its
-// air time and the canonical SongID it belongs to.
-func PlayDocID(airTime time.Time, songID string) string {
+// PlayDocID returns the deterministic Firestore ID for a Play. It is
+// based on the raw (untreated) title and artist exactly as they came
+// from the source so it stays stable when the normalization rules
+// evolve — re-normalizing only updates Play.SongID, the doc itself
+// keeps its identity.
+func PlayDocID(airTime time.Time, rawTitle, rawArtist string) string {
 	h := sha1.New()
-	fmt.Fprintf(h, "%d\x00%s", airTime.Unix(), songID)
+	fmt.Fprintf(h, "%d\x00%s\x00%s", airTime.Unix(), rawTitle, rawArtist)
 	return hex.EncodeToString(h.Sum(nil))
 }
 
@@ -129,7 +132,7 @@ func (app *App) InsertPlay(airTime *time.Time, rawTitle, rawArtist string) (*Pla
 	}
 
 	songID := SongID(rawTitle, rawArtist)
-	playID := PlayDocID(*airTime, songID)
+	playID := PlayDocID(*airTime, rawTitle, rawArtist)
 
 	playRef := app.Firestore().Collection(playsCollection).Doc(playID)
 	songRef := app.Firestore().Collection(songsCollection).Doc(songID)

--- a/app.go
+++ b/app.go
@@ -19,7 +19,10 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-const songsCollection = "songs"
+const (
+	songsCollection = "songs"
+	playsCollection = "plays"
+)
 
 func mustGetenv(k string) string {
 	v := os.Getenv(k)
@@ -86,8 +89,9 @@ func (app *App) ParseTime(str string) *time.Time {
 	return &t
 }
 
-func (app *App) LastSong() *Song {
-	iter := app.Firestore().Collection(songsCollection).
+// LastPlay returns the most recently aired Play, or nil if none exists.
+func (app *App) LastPlay() *Play {
+	iter := app.Firestore().Collection(playsCollection).
 		OrderBy("time", firestore.Desc).
 		Limit(1).
 		Documents(app.Context)
@@ -100,35 +104,83 @@ func (app *App) LastSong() *Song {
 		app.LogError(err)
 		return nil
 	}
-	var song Song
-	if err := doc.DataTo(&song); err != nil {
+	var play Play
+	if err := doc.DataTo(&play); err != nil {
 		app.LogError(err)
 		return nil
 	}
-	return &song
+	return &play
 }
 
-// SongDocID returns a deterministic document ID for a (time, title, artist) tuple.
-func SongDocID(songTime time.Time, title, artist string) string {
+// PlayDocID returns the deterministic Firestore ID for a Play given its
+// air time and the canonical SongID it belongs to.
+func PlayDocID(airTime time.Time, songID string) string {
 	h := sha1.New()
-	fmt.Fprintf(h, "%d\x00%s\x00%s", songTime.Unix(), title, artist)
+	fmt.Fprintf(h, "%d\x00%s", airTime.Unix(), songID)
 	return hex.EncodeToString(h.Sum(nil))
 }
 
-func (app *App) InsertSong(songTime *time.Time, title, artist string) (*Song, error) {
-	if songTime == nil {
-		return nil, nil
+// InsertPlay creates a Play and upserts the canonical Song it points to.
+// Returns (play, song, error). When the play already exists (same airtime
+// and song), play is nil to indicate "nothing new".
+func (app *App) InsertPlay(airTime *time.Time, rawTitle, rawArtist string) (*Play, *Song, error) {
+	if airTime == nil {
+		return nil, nil, nil
 	}
-	song := Song{Time: songTime, Artist: artist, Title: title}
-	id := SongDocID(*songTime, title, artist)
-	_, err := app.Firestore().Collection(songsCollection).Doc(id).Create(app.Context, song)
-	if err != nil {
+
+	songID := SongID(rawTitle, rawArtist)
+	playID := PlayDocID(*airTime, songID)
+
+	playRef := app.Firestore().Collection(playsCollection).Doc(playID)
+	songRef := app.Firestore().Collection(songsCollection).Doc(songID)
+
+	play := Play{
+		SongID:    songID,
+		Time:      airTime,
+		RawTitle:  rawTitle,
+		RawArtist: rawArtist,
+	}
+
+	if _, err := playRef.Create(app.Context, play); err != nil {
 		if status.Code(err) == codes.AlreadyExists {
-			return nil, nil
+			return nil, nil, nil
 		}
-		return nil, err
+		return nil, nil, err
 	}
-	return &song, nil
+
+	var resultSong Song
+	err := app.Firestore().RunTransaction(app.Context, func(ctx context.Context, tx *firestore.Transaction) error {
+		snap, err := tx.Get(songRef)
+		if status.Code(err) == codes.NotFound {
+			resultSong = Song{
+				Title:         DisplayClean(rawTitle),
+				Artist:        DisplayClean(rawArtist),
+				NormalizedKey: NormalizedKey(rawTitle, rawArtist),
+				FirstAired:    airTime,
+				LastAired:     airTime,
+				PlayCount:     1,
+			}
+			return tx.Create(songRef, resultSong)
+		}
+		if err != nil {
+			return err
+		}
+		if err := snap.DataTo(&resultSong); err != nil {
+			return err
+		}
+		if resultSong.FirstAired == nil || airTime.Before(*resultSong.FirstAired) {
+			resultSong.FirstAired = airTime
+		}
+		if resultSong.LastAired == nil || airTime.After(*resultSong.LastAired) {
+			resultSong.LastAired = airTime
+		}
+		resultSong.PlayCount++
+		return tx.Set(songRef, resultSong)
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return &play, &resultSong, nil
 }
 
 func (app *App) Visit(date time.Time) bool {
@@ -144,20 +196,22 @@ func (app *App) Visit(date time.Time) bool {
 	}
 	date = date.In(jst)
 	c := colly.NewCollector()
-	rows := []Song{}
+	var rows []PublishedPlay
 	c.OnHTML(".list_songs", func(e *colly.HTMLElement) {
 		e.ForEach(".song", func(index int, e *colly.HTMLElement) {
-			songTime := app.ParseTime(e.ChildText(".song_info .time span"))
-			if songTime == nil || !date.Before(*songTime) {
+			airTime := app.ParseTime(e.ChildText(".song_info .time span"))
+			if airTime == nil || !date.Before(*airTime) {
 				return
 			}
 			title := e.ChildText("h4")
 			artist := e.ChildText(".txt_artist span")
-			song, err := app.InsertSong(songTime, title, artist)
+			play, song, err := app.InsertPlay(airTime, title, artist)
 			if err != nil {
 				app.LogError(err)
-			} else if song != nil {
-				rows = append(rows, *song)
+				return
+			}
+			if play != nil && song != nil {
+				rows = append(rows, PublishedPlay{Play: *play, Song: *song})
 			}
 		})
 	})
@@ -169,15 +223,21 @@ func (app *App) Visit(date time.Time) bool {
 	})
 
 	c.Visit(date.Format("https://www.j-wave.co.jp/cgi-bin/soundsearch_result.cgi?year=2006&month=01&day=02&hour=15&minute=04"))
-	app.PublishNewSongs(rows)
+	app.PublishNewPlays(rows)
 	return app.Visit(date.Add(2 * time.Hour))
 }
 
-func (app *App) PublishNewSongs(songs []Song) {
-	if len(songs) == 0 {
+// PublishedPlay is the message body delivered to the notify topic.
+type PublishedPlay struct {
+	Play Play `json:"play"`
+	Song Song `json:"song"`
+}
+
+func (app *App) PublishNewPlays(rows []PublishedPlay) {
+	if len(rows) == 0 {
 		return
 	}
-	data, err := json.Marshal(songs)
+	data, err := json.Marshal(rows)
 	if err != nil {
 		app.LogError(err)
 		return

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,14 +1,28 @@
 {
-  "indexes": [],
+  "indexes": [
+    {
+      "collectionGroup": "plays",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "songId", "order": "ASCENDING" },
+        { "fieldPath": "time", "order": "DESCENDING" }
+      ]
+    }
+  ],
   "fieldOverrides": [
     {
-      "collectionGroup": "songs",
-      "fieldPath": "title",
+      "collectionGroup": "plays",
+      "fieldPath": "rawTitle",
+      "indexes": []
+    },
+    {
+      "collectionGroup": "plays",
+      "fieldPath": "rawArtist",
       "indexes": []
     },
     {
       "collectionGroup": "songs",
-      "fieldPath": "artist",
+      "fieldPath": "normalizedKey",
       "indexes": []
     }
   ]

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/ashwanthkumar/slack-go-webhook v0.0.0-20200209025033-430dd4e66960
 	github.com/cloudevents/sdk-go/v2 v2.14.0
 	github.com/gocolly/colly v1.2.0
+	golang.org/x/text v0.35.0
 	google.golang.org/api v0.149.0
 	google.golang.org/grpc v1.59.0
 )
@@ -54,7 +55,6 @@ require (
 	golang.org/x/oauth2 v0.13.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
-	golang.org/x/text v0.35.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/migrate/go.mod
+++ b/migrate/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	cloud.google.com/go/firestore v1.14.0
 	github.com/go-sql-driver/mysql v1.7.1
+	golang.org/x/text v0.13.0
 	google.golang.org/api v0.128.0
 )
 
@@ -25,7 +26,6 @@ require (
 	golang.org/x/oauth2 v0.8.0 // indirect
 	golang.org/x/sync v0.2.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
-	golang.org/x/text v0.13.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/migrate/main.go
+++ b/migrate/main.go
@@ -21,18 +21,15 @@ import (
 const (
 	songsCollection = "songs"
 	playsCollection = "plays"
+
+	rawTable    = "songs"  // existing raw airplay log
+	csongsTable = "csongs" // canonical songs (new)
+	playsTable  = "plays"  // airplays with normalized song_id (new)
 )
 
-func mustGetenv(k string) string {
-	v := os.Getenv(k)
-	if v == "" {
-		log.Fatalf("%s environment variable not set.", k)
-	}
-	return v
-}
+// ---------- normalization (mirrors onairlogsync.* so this module has no
+// runtime-package dependency) ----------
 
-// Mirror of onairlogsync.Normalize / DisplayClean. Kept inlined so the
-// migrate module does not have to depend on the runtime package.
 var (
 	parenRE = regexp.MustCompile(`[\(（\[［][^\)）\]］]*[\)）\]］]`)
 	featRE  = regexp.MustCompile(`(?i)\b(?:featuring|feat|ft)(?:\.|\b)`)
@@ -67,6 +64,400 @@ func playID(airTime time.Time, sid string) string {
 	return hashKey(fmt.Sprintf("%d\x00%s", airTime.Unix(), sid))
 }
 
+// ---------- env / connection helpers ----------
+
+func mustGetenv(k string) string {
+	v := os.Getenv(k)
+	if v == "" {
+		log.Fatalf("%s environment variable not set.", k)
+	}
+	return v
+}
+
+func openMySQL() *sql.DB {
+	dsn := mustGetenv("DATABASE_URI")
+	if !strings.Contains(dsn, "parseTime=") {
+		if strings.Contains(dsn, "?") {
+			dsn += "&parseTime=true"
+		} else {
+			dsn += "?parseTime=true"
+		}
+	}
+	if !strings.Contains(dsn, "loc=") {
+		dsn += "&loc=Asia%2FTokyo"
+	}
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		log.Fatalf("mysql open: %v", err)
+	}
+	if err := db.Ping(); err != nil {
+		log.Fatalf("mysql ping: %v", err)
+	}
+	return db
+}
+
+func openFirestore(ctx context.Context) *firestore.Client {
+	projectID := mustGetenv("PROJECT_ID")
+	dbName := os.Getenv("FIRESTORE_DATABASE")
+	if dbName == "" {
+		dbName = firestore.DefaultDatabaseID
+	}
+	fs, err := firestore.NewClientWithDatabase(ctx, projectID, dbName)
+	if err != nil {
+		log.Fatalf("firestore client: %v", err)
+	}
+	return fs
+}
+
+// ---------- main ----------
+
+func main() {
+	var (
+		prep        = flag.Bool("prep", false, "Phase 1: build csongs/plays in MySQL from raw songs")
+		reset       = flag.Bool("reset", false, "delete all docs in Firestore songs and plays, then exit")
+		chunkSize   = flag.Int64("chunk", 1000, "rows per chunk")
+		dryRun      = flag.Bool("dry-run", false, "do not write")
+		limit       = flag.Int64("limit", 0, "(prep) max source rows (0 = unlimited)")
+		startRawID  = flag.Int64("start-id", 0, "(prep) resume from raw songs id")
+		startPlayID = flag.String("start-play-id", "", "(import) resume from plays.id (hex)")
+		startSongID = flag.String("start-song-id", "", "(import) resume from csongs.id (hex)")
+	)
+	flag.Parse()
+
+	switch {
+	case *reset:
+		runReset()
+	case *prep:
+		runPrep(*startRawID, *limit, *chunkSize, *dryRun)
+	default:
+		runImport(*startPlayID, *startSongID, *chunkSize, *dryRun)
+	}
+}
+
+// ---------- Phase 1: prep MySQL tables ----------
+
+const ddlCsongs = `CREATE TABLE IF NOT EXISTS csongs (
+  id              VARCHAR(40)  NOT NULL PRIMARY KEY,
+  title           VARCHAR(500),
+  artist          VARCHAR(500),
+  normalized_key  VARCHAR(1000),
+  first_aired     DATETIME,
+  last_aired      DATETIME,
+  play_count      INT NOT NULL DEFAULT 0,
+  KEY idx_last_aired (last_aired)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`
+
+const ddlPlays = `CREATE TABLE IF NOT EXISTS plays (
+  id          VARCHAR(40) NOT NULL PRIMARY KEY,
+  song_id     VARCHAR(40) NOT NULL,
+  time        DATETIME NOT NULL,
+  raw_title   VARCHAR(500),
+  raw_artist  VARCHAR(500),
+  KEY idx_time (time),
+  KEY idx_song_id_time (song_id, time)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`
+
+func runPrep(startID, limit, chunkSize int64, dryRun bool) {
+	db := openMySQL()
+	defer db.Close()
+	ctx := context.Background()
+
+	if !dryRun {
+		if _, err := db.ExecContext(ctx, ddlCsongs); err != nil {
+			log.Fatalf("create csongs: %v", err)
+		}
+		if _, err := db.ExecContext(ctx, ddlPlays); err != nil {
+			log.Fatalf("create plays: %v", err)
+		}
+	}
+
+	stmtSong, err := db.PrepareContext(ctx, `INSERT INTO `+csongsTable+`
+        (id, title, artist, normalized_key, first_aired, last_aired, play_count)
+        VALUES (?, ?, ?, ?, ?, ?, 1)
+        ON DUPLICATE KEY UPDATE
+          first_aired = LEAST(first_aired, VALUES(first_aired)),
+          last_aired  = GREATEST(last_aired, VALUES(last_aired)),
+          play_count  = play_count + 1`)
+	if err != nil {
+		log.Fatalf("prepare song: %v", err)
+	}
+	defer stmtSong.Close()
+
+	stmtPlay, err := db.PrepareContext(ctx, `INSERT IGNORE INTO `+playsTable+`
+        (id, song_id, time, raw_title, raw_artist)
+        VALUES (?, ?, ?, ?, ?)`)
+	if err != nil {
+		log.Fatalf("prepare play: %v", err)
+	}
+	defer stmtPlay.Close()
+
+	var (
+		lastID    = startID
+		processed int64
+	)
+	start := time.Now()
+	for {
+		batch := chunkSize
+		if limit > 0 {
+			remaining := limit - processed
+			if remaining <= 0 {
+				break
+			}
+			if remaining < batch {
+				batch = remaining
+			}
+		}
+
+		rows, err := db.QueryContext(ctx,
+			`SELECT id, time, title, artist FROM `+rawTable+`
+			 WHERE id > ? AND deleted_at IS NULL AND time IS NOT NULL
+			 ORDER BY id ASC LIMIT ?`, lastID, batch)
+		if err != nil {
+			log.Fatalf("query raw: %v", err)
+		}
+
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			rows.Close()
+			log.Fatalf("begin tx: %v", err)
+		}
+		txStmtSong := tx.StmtContext(ctx, stmtSong)
+		txStmtPlay := tx.StmtContext(ctx, stmtPlay)
+
+		var got int64
+		for rows.Next() {
+			var (
+				id     int64
+				t      time.Time
+				title  sql.NullString
+				artist sql.NullString
+			)
+			if err := rows.Scan(&id, &t, &title, &artist); err != nil {
+				rows.Close()
+				_ = tx.Rollback()
+				log.Fatalf("scan: %v", err)
+			}
+			lastID = id
+			got++
+			processed++
+
+			rawTitle := title.String
+			rawArtist := artist.String
+			sid := songID(rawTitle, rawArtist)
+			pid := playID(t, sid)
+			nKey := normalize(rawTitle) + "|" + normalize(rawArtist)
+
+			if dryRun {
+				continue
+			}
+			if _, err := txStmtSong.ExecContext(ctx,
+				sid, displayClean(rawTitle), displayClean(rawArtist), nKey, t, t); err != nil {
+				rows.Close()
+				_ = tx.Rollback()
+				log.Fatalf("insert csong: %v", err)
+			}
+			if _, err := txStmtPlay.ExecContext(ctx,
+				pid, sid, t, rawTitle, rawArtist); err != nil {
+				rows.Close()
+				_ = tx.Rollback()
+				log.Fatalf("insert play: %v", err)
+			}
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			_ = tx.Rollback()
+			log.Fatalf("rows.Err: %v", err)
+		}
+		rows.Close()
+
+		if got == 0 {
+			_ = tx.Rollback()
+			break
+		}
+
+		if dryRun {
+			_ = tx.Rollback()
+		} else if err := tx.Commit(); err != nil {
+			log.Fatalf("commit: %v", err)
+		}
+
+		elapsed := time.Since(start).Seconds()
+		rate := float64(processed) / elapsed
+		log.Printf("prep processed=%d lastID=%d elapsed=%.0fs rate=%.0f/s",
+			processed, lastID, elapsed, rate)
+	}
+
+	log.Printf("prep done. processed=%d lastID=%d total=%.0fs",
+		processed, lastID, time.Since(start).Seconds())
+}
+
+// ---------- Phase 2: import to Firestore ----------
+
+func runImport(startPlayID, startSongID string, chunkSize int64, dryRun bool) {
+	db := openMySQL()
+	defer db.Close()
+	ctx := context.Background()
+	fs := openFirestore(ctx)
+	defer fs.Close()
+
+	importPlays(ctx, db, fs, startPlayID, chunkSize, dryRun)
+	importSongs(ctx, db, fs, startSongID, chunkSize, dryRun)
+}
+
+func importPlays(ctx context.Context, db *sql.DB, fs *firestore.Client, startID string, chunkSize int64, dryRun bool) {
+	bw := fs.BulkWriter(ctx)
+	col := fs.Collection(playsCollection)
+
+	var (
+		lastID    = startID
+		processed int64
+	)
+	start := time.Now()
+	for {
+		rows, err := db.QueryContext(ctx,
+			`SELECT id, song_id, time, raw_title, raw_artist FROM `+playsTable+`
+			 WHERE id > ? ORDER BY id ASC LIMIT ?`, lastID, chunkSize)
+		if err != nil {
+			log.Fatalf("query plays: %v", err)
+		}
+
+		var got int64
+		for rows.Next() {
+			var (
+				id        string
+				sid       string
+				t         time.Time
+				rawTitle  sql.NullString
+				rawArtist sql.NullString
+			)
+			if err := rows.Scan(&id, &sid, &t, &rawTitle, &rawArtist); err != nil {
+				rows.Close()
+				log.Fatalf("scan play: %v", err)
+			}
+			lastID = id
+			got++
+			processed++
+
+			if dryRun {
+				continue
+			}
+			tt := t
+			if _, err := bw.Set(col.Doc(id), playDoc{
+				SongID:    sid,
+				Time:      &tt,
+				RawTitle:  rawTitle.String,
+				RawArtist: rawArtist.String,
+			}); err != nil {
+				rows.Close()
+				log.Fatalf("bw set play: %v", err)
+			}
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			log.Fatalf("rows.Err: %v", err)
+		}
+		rows.Close()
+
+		if got == 0 {
+			break
+		}
+		if !dryRun {
+			bw.Flush()
+		}
+		elapsed := time.Since(start).Seconds()
+		rate := float64(processed) / elapsed
+		log.Printf("plays imported=%d lastID=%s elapsed=%.0fs rate=%.0f/s",
+			processed, lastID, elapsed, rate)
+	}
+	if !dryRun {
+		bw.End()
+	}
+	log.Printf("plays import done. processed=%d total=%.0fs", processed, time.Since(start).Seconds())
+}
+
+func importSongs(ctx context.Context, db *sql.DB, fs *firestore.Client, startID string, chunkSize int64, dryRun bool) {
+	bw := fs.BulkWriter(ctx)
+	col := fs.Collection(songsCollection)
+
+	var (
+		lastID    = startID
+		processed int64
+	)
+	start := time.Now()
+	for {
+		rows, err := db.QueryContext(ctx,
+			`SELECT id, title, artist, normalized_key, first_aired, last_aired, play_count FROM `+csongsTable+`
+			 WHERE id > ? ORDER BY id ASC LIMIT ?`, lastID, chunkSize)
+		if err != nil {
+			log.Fatalf("query csongs: %v", err)
+		}
+
+		var got int64
+		for rows.Next() {
+			var (
+				id        string
+				title     sql.NullString
+				artist    sql.NullString
+				nkey      sql.NullString
+				first     sql.NullTime
+				last      sql.NullTime
+				playCount int
+			)
+			if err := rows.Scan(&id, &title, &artist, &nkey, &first, &last, &playCount); err != nil {
+				rows.Close()
+				log.Fatalf("scan song: %v", err)
+			}
+			lastID = id
+			got++
+			processed++
+
+			if dryRun {
+				continue
+			}
+			doc := songDoc{
+				Title:         title.String,
+				Artist:        artist.String,
+				NormalizedKey: nkey.String,
+				PlayCount:     playCount,
+			}
+			if first.Valid {
+				v := first.Time
+				doc.FirstAired = &v
+			}
+			if last.Valid {
+				v := last.Time
+				doc.LastAired = &v
+			}
+			if _, err := bw.Set(col.Doc(id), doc); err != nil {
+				rows.Close()
+				log.Fatalf("bw set song: %v", err)
+			}
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			log.Fatalf("rows.Err: %v", err)
+		}
+		rows.Close()
+
+		if got == 0 {
+			break
+		}
+		if !dryRun {
+			bw.Flush()
+		}
+		elapsed := time.Since(start).Seconds()
+		rate := float64(processed) / elapsed
+		log.Printf("songs imported=%d lastID=%s elapsed=%.0fs rate=%.0f/s",
+			processed, lastID, elapsed, rate)
+	}
+	if !dryRun {
+		bw.End()
+	}
+	log.Printf("songs import done. processed=%d total=%.0fs", processed, time.Since(start).Seconds())
+}
+
+// ---------- Firestore docs ----------
+
 type songDoc struct {
 	Title         string     `firestore:"title"`
 	Artist        string     `firestore:"artist"`
@@ -83,204 +474,11 @@ type playDoc struct {
 	RawArtist string     `firestore:"rawArtist"`
 }
 
-func main() {
-	startID := flag.Int64("start-id", 0, "resume from this MySQL id (exclusive)")
-	limit := flag.Int64("limit", 0, "max rows to migrate (0 = unlimited)")
-	chunkSize := flag.Int64("chunk", 1000, "rows per chunk")
-	dryRun := flag.Bool("dry-run", false, "do not write to Firestore")
-	reset := flag.Bool("reset", false, "delete all docs in songs and plays, then exit")
-	flag.Parse()
-
-	if *reset {
-		runReset()
-		return
-	}
-
-	dsn := mustGetenv("DATABASE_URI")
-	if !strings.Contains(dsn, "parseTime=") {
-		if strings.Contains(dsn, "?") {
-			dsn += "&parseTime=true"
-		} else {
-			dsn += "?parseTime=true"
-		}
-	}
-	if !strings.Contains(dsn, "loc=") {
-		dsn += "&loc=Asia%2FTokyo"
-	}
-	projectID := mustGetenv("PROJECT_ID")
-
-	db, err := sql.Open("mysql", dsn)
-	if err != nil {
-		log.Fatalf("mysql open: %v", err)
-	}
-	defer db.Close()
-	if err := db.Ping(); err != nil {
-		log.Fatalf("mysql ping: %v", err)
-	}
-
-	ctx := context.Background()
-	dbName := os.Getenv("FIRESTORE_DATABASE")
-	if dbName == "" {
-		dbName = firestore.DefaultDatabaseID
-	}
-	fs, err := firestore.NewClientWithDatabase(ctx, projectID, dbName)
-	if err != nil {
-		log.Fatalf("firestore client: %v", err)
-	}
-	defer fs.Close()
-
-	bw := fs.BulkWriter(ctx)
-
-	songMeta := make(map[string]songDoc)
-	seenPlay := make(map[string]struct{})
-
-	var (
-		lastID    = *startID
-		processed int64
-		queued    int64
-		duplicate int64
-	)
-
-	start := time.Now()
-	for {
-		batch := *chunkSize
-		if *limit > 0 {
-			remaining := *limit - processed
-			if remaining <= 0 {
-				break
-			}
-			if remaining < batch {
-				batch = remaining
-			}
-		}
-
-		rows, err := db.QueryContext(ctx,
-			`SELECT id, time, title, artist FROM songs
-			 WHERE id > ? AND deleted_at IS NULL AND time IS NOT NULL
-			 ORDER BY id ASC
-			 LIMIT ?`, lastID, batch)
-		if err != nil {
-			log.Fatalf("query: %v", err)
-		}
-
-		var got int64
-		for rows.Next() {
-			var (
-				id     int64
-				t      time.Time
-				title  sql.NullString
-				artist sql.NullString
-			)
-			if err := rows.Scan(&id, &t, &title, &artist); err != nil {
-				rows.Close()
-				log.Fatalf("scan: %v", err)
-			}
-			lastID = id
-			got++
-			processed++
-
-			rawTitle := title.String
-			rawArtist := artist.String
-			sid := songID(rawTitle, rawArtist)
-			pid := playID(t, sid)
-
-			if _, ok := seenPlay[pid]; ok {
-				duplicate++
-				continue
-			}
-			seenPlay[pid] = struct{}{}
-
-			tt := t
-
-			meta, exists := songMeta[sid]
-			if !exists {
-				meta = songDoc{
-					Title:         displayClean(rawTitle),
-					Artist:        displayClean(rawArtist),
-					NormalizedKey: normalize(rawTitle) + "|" + normalize(rawArtist),
-					FirstAired:    &tt,
-					LastAired:     &tt,
-				}
-			} else {
-				if meta.FirstAired == nil || tt.Before(*meta.FirstAired) {
-					meta.FirstAired = &tt
-				}
-				if meta.LastAired == nil || tt.After(*meta.LastAired) {
-					meta.LastAired = &tt
-				}
-			}
-			meta.PlayCount++
-			songMeta[sid] = meta
-
-			if *dryRun {
-				continue
-			}
-
-			doc := fs.Collection(playsCollection).Doc(pid)
-			if _, err := bw.Set(doc, playDoc{
-				SongID:    sid,
-				Time:      &tt,
-				RawTitle:  rawTitle,
-				RawArtist: rawArtist,
-			}); err != nil {
-				rows.Close()
-				log.Fatalf("bulkwriter set play: %v", err)
-			}
-			queued++
-		}
-		if err := rows.Err(); err != nil {
-			rows.Close()
-			log.Fatalf("rows.Err: %v", err)
-		}
-		rows.Close()
-
-		if got == 0 {
-			break
-		}
-
-		if !*dryRun {
-			bw.Flush()
-		}
-		elapsed := time.Since(start).Seconds()
-		rate := float64(processed) / elapsed
-		log.Printf("plays processed=%d queued=%d duplicate=%d unique-songs=%d lastID=%d elapsed=%.0fs rate=%.0f/s",
-			processed, queued, duplicate, len(songMeta), lastID, elapsed, rate)
-	}
-
-	log.Printf("plays import done. processed=%d queued=%d duplicate=%d unique-songs=%d",
-		processed, queued, duplicate, len(songMeta))
-
-	if !*dryRun {
-		var songsWritten int64
-		for sid, meta := range songMeta {
-			doc := fs.Collection(songsCollection).Doc(sid)
-			if _, err := bw.Set(doc, meta); err != nil {
-				log.Fatalf("bulkwriter set song: %v", err)
-			}
-			songsWritten++
-			if songsWritten%5000 == 0 {
-				bw.Flush()
-				log.Printf("songs queued=%d / %d", songsWritten, len(songMeta))
-			}
-		}
-		bw.End()
-		log.Printf("songs import done. wrote=%d", songsWritten)
-	}
-
-	log.Printf("done. total=%.0fs", time.Since(start).Seconds())
-}
+// ---------- Reset ----------
 
 func runReset() {
-	projectID := mustGetenv("PROJECT_ID")
 	ctx := context.Background()
-	dbName := os.Getenv("FIRESTORE_DATABASE")
-	if dbName == "" {
-		dbName = firestore.DefaultDatabaseID
-	}
-	fs, err := firestore.NewClientWithDatabase(ctx, projectID, dbName)
-	if err != nil {
-		log.Fatalf("firestore client: %v", err)
-	}
+	fs := openFirestore(ctx)
 	defer fs.Close()
 
 	for _, name := range []string{playsCollection, songsCollection} {

--- a/migrate/main.go
+++ b/migrate/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -17,7 +18,10 @@ import (
 	"google.golang.org/api/iterator"
 )
 
-const collection = "songs"
+const (
+	songsCollection = "songs"
+	playsCollection = "plays"
+)
 
 func mustGetenv(k string) string {
 	v := os.Getenv(k)
@@ -27,16 +31,56 @@ func mustGetenv(k string) string {
 	return v
 }
 
-func songDocID(songTime time.Time, title, artist string) string {
+// Mirror of onairlogsync.Normalize / DisplayClean. Kept inlined so the
+// migrate module does not have to depend on the runtime package.
+var (
+	parenRE = regexp.MustCompile(`[\(（\[［][^\)）\]］]*[\)）\]］]`)
+	featRE  = regexp.MustCompile(`(?i)\b(?:featuring|feat|ft)(?:\.|\b)`)
+	wsRE    = regexp.MustCompile(`\s+`)
+)
+
+func displayClean(s string) string {
+	s = parenRE.ReplaceAllString(s, " ")
+	s = wsRE.ReplaceAllString(s, " ")
+	return strings.TrimSpace(s)
+}
+
+func normalize(s string) string {
+	s = parenRE.ReplaceAllString(s, " ")
+	s = strings.ToLower(s)
+	s = featRE.ReplaceAllString(s, "feat.")
+	s = wsRE.ReplaceAllString(s, " ")
+	return strings.TrimSpace(s)
+}
+
+func hashKey(s string) string {
 	h := sha1.New()
-	fmt.Fprintf(h, "%d\x00%s\x00%s", songTime.Unix(), title, artist)
+	fmt.Fprint(h, s)
 	return hex.EncodeToString(h.Sum(nil))
 }
 
+func songID(title, artist string) string {
+	return hashKey(normalize(title) + "\x00" + normalize(artist))
+}
+
+func playID(airTime time.Time, sid string) string {
+	return hashKey(fmt.Sprintf("%d\x00%s", airTime.Unix(), sid))
+}
+
 type songDoc struct {
-	Time   *time.Time `firestore:"time"`
-	Artist string     `firestore:"artist"`
-	Title  string     `firestore:"title"`
+	Title         string     `firestore:"title"`
+	Artist        string     `firestore:"artist"`
+	NormalizedKey string     `firestore:"normalizedKey"`
+	FirstAired    *time.Time `firestore:"firstAired"`
+	LastAired     *time.Time `firestore:"lastAired"`
+	PlayCount     int        `firestore:"playCount"`
+}
+
+type playDoc struct {
+	SongID    string     `firestore:"songId"`
+	Time      *time.Time `firestore:"time"`
+	RawTitle  string     `firestore:"rawTitle"`
+	RawArtist string     `firestore:"rawArtist"`
 }
 
 func main() {
@@ -44,7 +88,7 @@ func main() {
 	limit := flag.Int64("limit", 0, "max rows to migrate (0 = unlimited)")
 	chunkSize := flag.Int64("chunk", 1000, "rows per chunk")
 	dryRun := flag.Bool("dry-run", false, "do not write to Firestore")
-	reset := flag.Bool("reset", false, "delete all docs in the songs collection and exit")
+	reset := flag.Bool("reset", false, "delete all docs in songs and plays, then exit")
 	flag.Parse()
 
 	if *reset {
@@ -60,9 +104,6 @@ func main() {
 			dsn += "?parseTime=true"
 		}
 	}
-	// MySQL DATETIME values were written by gorm with loc=Asia/Tokyo, so
-	// they hold raw JST values. Without specifying loc here, the driver
-	// would interpret them as UTC and shift every timestamp by +9h.
 	if !strings.Contains(dsn, "loc=") {
 		dsn += "&loc=Asia%2FTokyo"
 	}
@@ -90,10 +131,8 @@ func main() {
 
 	bw := fs.BulkWriter(ctx)
 
-	// BulkWriter rejects multiple writes against the same document path.
-	// MySQL has duplicate (time, title, artist) rows, so dedupe by docID
-	// in-process before enqueueing.
-	seen := make(map[string]struct{})
+	songMeta := make(map[string]songDoc)
+	seenPlay := make(map[string]struct{})
 
 	var (
 		lastID    = *startID
@@ -140,21 +179,52 @@ func main() {
 			got++
 			processed++
 
-			tt := t
-			docID := songDocID(tt, title.String, artist.String)
-			if _, ok := seen[docID]; ok {
+			rawTitle := title.String
+			rawArtist := artist.String
+			sid := songID(rawTitle, rawArtist)
+			pid := playID(t, sid)
+
+			if _, ok := seenPlay[pid]; ok {
 				duplicate++
 				continue
 			}
-			seen[docID] = struct{}{}
+			seenPlay[pid] = struct{}{}
+
+			tt := t
+
+			meta, exists := songMeta[sid]
+			if !exists {
+				meta = songDoc{
+					Title:         displayClean(rawTitle),
+					Artist:        displayClean(rawArtist),
+					NormalizedKey: normalize(rawTitle) + "|" + normalize(rawArtist),
+					FirstAired:    &tt,
+					LastAired:     &tt,
+				}
+			} else {
+				if meta.FirstAired == nil || tt.Before(*meta.FirstAired) {
+					meta.FirstAired = &tt
+				}
+				if meta.LastAired == nil || tt.After(*meta.LastAired) {
+					meta.LastAired = &tt
+				}
+			}
+			meta.PlayCount++
+			songMeta[sid] = meta
 
 			if *dryRun {
 				continue
 			}
-			doc := fs.Collection(collection).Doc(docID)
-			if _, err := bw.Set(doc, songDoc{Time: &tt, Artist: artist.String, Title: title.String}); err != nil {
+
+			doc := fs.Collection(playsCollection).Doc(pid)
+			if _, err := bw.Set(doc, playDoc{
+				SongID:    sid,
+				Time:      &tt,
+				RawTitle:  rawTitle,
+				RawArtist: rawArtist,
+			}); err != nil {
 				rows.Close()
-				log.Fatalf("bulkwriter set: %v", err)
+				log.Fatalf("bulkwriter set play: %v", err)
 			}
 			queued++
 		}
@@ -173,15 +243,31 @@ func main() {
 		}
 		elapsed := time.Since(start).Seconds()
 		rate := float64(processed) / elapsed
-		log.Printf("processed=%d queued=%d duplicate=%d lastID=%d elapsed=%.0fs rate=%.0f/s",
-			processed, queued, duplicate, lastID, elapsed, rate)
+		log.Printf("plays processed=%d queued=%d duplicate=%d unique-songs=%d lastID=%d elapsed=%.0fs rate=%.0f/s",
+			processed, queued, duplicate, len(songMeta), lastID, elapsed, rate)
 	}
 
+	log.Printf("plays import done. processed=%d queued=%d duplicate=%d unique-songs=%d",
+		processed, queued, duplicate, len(songMeta))
+
 	if !*dryRun {
+		var songsWritten int64
+		for sid, meta := range songMeta {
+			doc := fs.Collection(songsCollection).Doc(sid)
+			if _, err := bw.Set(doc, meta); err != nil {
+				log.Fatalf("bulkwriter set song: %v", err)
+			}
+			songsWritten++
+			if songsWritten%5000 == 0 {
+				bw.Flush()
+				log.Printf("songs queued=%d / %d", songsWritten, len(songMeta))
+			}
+		}
 		bw.End()
+		log.Printf("songs import done. wrote=%d", songsWritten)
 	}
-	log.Printf("done. processed=%d queued=%d duplicate=%d lastID=%d total=%.0fs",
-		processed, queued, duplicate, lastID, time.Since(start).Seconds())
+
+	log.Printf("done. total=%.0fs", time.Since(start).Seconds())
 }
 
 func runReset() {
@@ -197,8 +283,15 @@ func runReset() {
 	}
 	defer fs.Close()
 
+	for _, name := range []string{playsCollection, songsCollection} {
+		log.Printf("resetting collection %q...", name)
+		deleteCollection(ctx, fs, name)
+	}
+}
+
+func deleteCollection(ctx context.Context, fs *firestore.Client, name string) {
 	bw := fs.BulkWriter(ctx)
-	col := fs.Collection(collection)
+	col := fs.Collection(name)
 	const pageSize = 500
 
 	var deleted int64
@@ -228,9 +321,9 @@ func runReset() {
 		}
 		bw.Flush()
 		elapsed := time.Since(start).Seconds()
-		log.Printf("deleted=%d elapsed=%.0fs rate=%.0f/s",
-			deleted, elapsed, float64(deleted)/elapsed)
+		log.Printf("[%s] deleted=%d elapsed=%.0fs rate=%.0f/s",
+			name, deleted, elapsed, float64(deleted)/elapsed)
 	}
 	bw.End()
-	log.Printf("reset done. deleted=%d total=%.0fs", deleted, time.Since(start).Seconds())
+	log.Printf("[%s] reset done. deleted=%d total=%.0fs", name, deleted, time.Since(start).Seconds())
 }

--- a/migrate/main.go
+++ b/migrate/main.go
@@ -15,6 +15,7 @@ import (
 
 	"cloud.google.com/go/firestore"
 	_ "github.com/go-sql-driver/mysql"
+	"golang.org/x/text/unicode/norm"
 	"google.golang.org/api/iterator"
 )
 
@@ -31,21 +32,49 @@ const (
 // runtime-package dependency) ----------
 
 var (
-	parenRE = regexp.MustCompile(`[\(（\[［][^\)）\]］]*[\)）\]］]`)
-	featRE  = regexp.MustCompile(`(?i)\b(?:featuring|feat|ft)(?:\.|\b)`)
-	wsRE    = regexp.MustCompile(`\s+`)
+	parenRE     = regexp.MustCompile(`[\(（\[［][^\)）\]］]*[\)）\]］]`)
+	featRE      = regexp.MustCompile(`(?i)\b(?:featuring|feat|ft)(?:\.|\b)`)
+	sepRE       = regexp.MustCompile(`(?i)[&+,/]|\band\b`)
+	punctRE     = regexp.MustCompile(`[^\p{L}\p{N}\s]`)
+	wsRE        = regexp.MustCompile(`\s+`)
+	invisibleRE = regexp.MustCompile(`[\x00-\x08\x0B\x0C\x0E-\x1F\x7F\x{00AD}\x{200B}-\x{200F}\x{202A}-\x{202E}\x{2060}-\x{206F}\x{FEFF}]`)
 )
 
 func displayClean(s string) string {
+	s = invisibleRE.ReplaceAllString(s, "")
 	s = parenRE.ReplaceAllString(s, " ")
 	s = wsRE.ReplaceAllString(s, " ")
+	s = strings.TrimSpace(s)
+	s = stripOuterQuotes(s)
 	return strings.TrimSpace(s)
 }
 
+var outerQuotes = [][2]string{
+	{`"`, `"`},
+	{`'`, `'`},
+	{"“", "”"},
+	{"‘", "’"},
+}
+
+func stripOuterQuotes(s string) string {
+	for _, p := range outerQuotes {
+		if len(s) >= len(p[0])+len(p[1]) &&
+			strings.HasPrefix(s, p[0]) &&
+			strings.HasSuffix(s, p[1]) {
+			return s[len(p[0]) : len(s)-len(p[1])]
+		}
+	}
+	return s
+}
+
 func normalize(s string) string {
+	s = invisibleRE.ReplaceAllString(s, "")
+	s = norm.NFKC.String(s)
 	s = parenRE.ReplaceAllString(s, " ")
 	s = strings.ToLower(s)
-	s = featRE.ReplaceAllString(s, "feat.")
+	s = featRE.ReplaceAllString(s, " ")
+	s = sepRE.ReplaceAllString(s, " ")
+	s = punctRE.ReplaceAllString(s, " ")
 	s = wsRE.ReplaceAllString(s, " ")
 	return strings.TrimSpace(s)
 }
@@ -60,8 +89,10 @@ func songID(title, artist string) string {
 	return hashKey(normalize(title) + "\x00" + normalize(artist))
 }
 
-func playID(airTime time.Time, sid string) string {
-	return hashKey(fmt.Sprintf("%d\x00%s", airTime.Unix(), sid))
+// playID is keyed off the raw title/artist (not the normalized songId)
+// so it stays stable when the normalization rules evolve.
+func playID(airTime time.Time, rawTitle, rawArtist string) string {
+	return hashKey(fmt.Sprintf("%d\x00%s\x00%s", airTime.Unix(), rawTitle, rawArtist))
 }
 
 // ---------- env / connection helpers ----------
@@ -244,7 +275,7 @@ func runPrep(startID, limit, chunkSize int64, dryRun bool) {
 			rawTitle := title.String
 			rawArtist := artist.String
 			sid := songID(rawTitle, rawArtist)
-			pid := playID(t, sid)
+			pid := playID(t, rawTitle, rawArtist)
 			nKey := normalize(rawTitle) + "|" + normalize(rawArtist)
 
 			if dryRun {

--- a/normalize.go
+++ b/normalize.go
@@ -1,0 +1,53 @@
+package onairlogsync
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var (
+	parenRE = regexp.MustCompile(`[\(（\[［][^\)）\]］]*[\)）\]］]`)
+	featRE  = regexp.MustCompile(`(?i)\b(?:featuring|feat|ft)(?:\.|\b)`)
+	wsRE    = regexp.MustCompile(`\s+`)
+)
+
+// DisplayClean strips bracketed annotations like "(2009 Remaster)" or
+// "(生演奏)" while preserving the original casing for display purposes.
+func DisplayClean(s string) string {
+	s = parenRE.ReplaceAllString(s, " ")
+	s = wsRE.ReplaceAllString(s, " ")
+	return strings.TrimSpace(s)
+}
+
+// Normalize lowercases, drops bracketed annotations, unifies the
+// feat./ft./featuring spelling, and collapses whitespace. Output is
+// suitable for matching but not for display.
+func Normalize(s string) string {
+	s = parenRE.ReplaceAllString(s, " ")
+	s = strings.ToLower(s)
+	s = featRE.ReplaceAllString(s, "feat.")
+	s = wsRE.ReplaceAllString(s, " ")
+	return strings.TrimSpace(s)
+}
+
+// SongID is the deterministic Firestore document ID for a (title, artist)
+// pair, derived from their normalized form so different transcriptions of
+// the same song collapse to one canonical document.
+func SongID(title, artist string) string {
+	return hashKey(Normalize(title) + "\x00" + Normalize(artist))
+}
+
+// NormalizedKey returns the matching key stored on the Song document for
+// debugging and possible future re-normalization.
+func NormalizedKey(title, artist string) string {
+	return Normalize(title) + "|" + Normalize(artist)
+}
+
+func hashKey(s string) string {
+	h := sha1.New()
+	fmt.Fprint(h, s)
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/normalize.go
+++ b/normalize.go
@@ -6,29 +6,71 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"golang.org/x/text/unicode/norm"
 )
 
 var (
 	parenRE = regexp.MustCompile(`[\(（\[［][^\)）\]］]*[\)）\]］]`)
 	featRE  = regexp.MustCompile(`(?i)\b(?:featuring|feat|ft)(?:\.|\b)`)
+	sepRE   = regexp.MustCompile(`(?i)[&+,/]|\band\b`)
+	punctRE = regexp.MustCompile(`[^\p{L}\p{N}\s]`)
 	wsRE    = regexp.MustCompile(`\s+`)
+	// Soft hyphen, zero-width chars, BOM, and other format/control
+	// characters that survive whitespace trimming and are never
+	// legitimate display content.
+	invisibleRE = regexp.MustCompile(`[\x00-\x08\x0B\x0C\x0E-\x1F\x7F\x{00AD}\x{200B}-\x{200F}\x{202A}-\x{202E}\x{2060}-\x{206F}\x{FEFF}]`)
 )
 
 // DisplayClean strips bracketed annotations like "(2009 Remaster)" or
-// "(生演奏)" while preserving the original casing for display purposes.
+// "(生演奏)" and unwraps the entire string when it is enclosed in matching
+// quotes (e.g. `"HEROES"` -> `HEROES`). Casing is preserved. Zero-width
+// characters, BOM, soft hyphens, and other invisible format characters
+// are removed so they cannot create silent duplicates.
 func DisplayClean(s string) string {
+	s = invisibleRE.ReplaceAllString(s, "")
 	s = parenRE.ReplaceAllString(s, " ")
 	s = wsRE.ReplaceAllString(s, " ")
+	s = strings.TrimSpace(s)
+	s = stripOuterQuotes(s)
 	return strings.TrimSpace(s)
 }
 
-// Normalize lowercases, drops bracketed annotations, unifies the
-// feat./ft./featuring spelling, and collapses whitespace. Output is
-// suitable for matching but not for display.
+var outerQuotes = [][2]string{
+	{`"`, `"`},
+	{`'`, `'`},
+	{"“", "”"}, // “ ”
+	{"‘", "’"}, // ‘ ’
+}
+
+func stripOuterQuotes(s string) string {
+	for _, p := range outerQuotes {
+		if len(s) >= len(p[0])+len(p[1]) &&
+			strings.HasPrefix(s, p[0]) &&
+			strings.HasSuffix(s, p[1]) {
+			return s[len(p[0]) : len(s)-len(p[1])]
+		}
+	}
+	return s
+}
+
+// Normalize collapses surface-form variation that should not produce
+// separate Songs. Steps:
+//   1. NFKC: halfwidth katakana → fullwidth, fullwidth ASCII → halfwidth.
+//   2. Drop bracketed annotations like "(Live)" / "(2009 Remaster)".
+//   3. Lowercase (Latin only; no-op for CJK).
+//   4. Drop "feat." / "ft." / "featuring" tokens.
+//   5. Treat &, +, /, ",", and the word "and" as artist separators.
+//   6. Strip remaining punctuation (quotes, hyphens, "#", "!", ".", ...).
+//   7. Collapse whitespace.
 func Normalize(s string) string {
+	s = invisibleRE.ReplaceAllString(s, "")
+	s = norm.NFKC.String(s)
 	s = parenRE.ReplaceAllString(s, " ")
 	s = strings.ToLower(s)
-	s = featRE.ReplaceAllString(s, "feat.")
+	s = featRE.ReplaceAllString(s, " ")
+	s = sepRE.ReplaceAllString(s, " ")
+	s = punctRE.ReplaceAllString(s, " ")
 	s = wsRE.ReplaceAllString(s, " ")
 	return strings.TrimSpace(s)
 }

--- a/normalize_test.go
+++ b/normalize_test.go
@@ -1,0 +1,57 @@
+package onairlogsync
+
+import "testing"
+
+func TestNormalize(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"Yesterday", "yesterday"},
+		{"YESTERDAY", "yesterday"},
+		{"  Yesterday  ", "yesterday"},
+		{"Yesterday (2009 Remaster)", "yesterday"},
+		{"曲名(生演奏)", "曲名"},
+		{"曲名(生演奏)(Live)", "曲名"},
+		{"曲名（フルバージョン）", "曲名"},
+		{"曲名[Live at Tokyo]", "曲名"},
+		{"曲名［ライブ］", "曲名"},
+		{"DAOKO ft. 米津玄師", "daoko feat. 米津玄師"},
+		{"DAOKO Ft 米津玄師", "daoko feat. 米津玄師"},
+		{"DAOKO featuring 米津玄師", "daoko feat. 米津玄師"},
+		{"a   b\tc", "a b c"},
+	}
+	for _, c := range cases {
+		got := Normalize(c.in)
+		if got != c.want {
+			t.Errorf("Normalize(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestDisplayClean(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"YESTERDAY", "YESTERDAY"},
+		{"Yesterday (2009 Remaster)", "Yesterday"},
+		{"曲名(生演奏)", "曲名"},
+		{"  曲名  ", "曲名"},
+	}
+	for _, c := range cases {
+		got := DisplayClean(c.in)
+		if got != c.want {
+			t.Errorf("DisplayClean(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestSongIDStability(t *testing.T) {
+	// Different surface forms of the same song should hash to the same
+	// canonical SongID.
+	a := SongID("Yesterday", "The Beatles")
+	b := SongID("YESTERDAY (2009 Remaster)", "the beatles")
+	c := SongID("yesterday  ", " The Beatles ")
+	if a != b || b != c {
+		t.Errorf("SongID variants do not match: %s %s %s", a, b, c)
+	}
+}

--- a/normalize_test.go
+++ b/normalize_test.go
@@ -15,10 +15,40 @@ func TestNormalize(t *testing.T) {
 		{"曲名（フルバージョン）", "曲名"},
 		{"曲名[Live at Tokyo]", "曲名"},
 		{"曲名［ライブ］", "曲名"},
-		{"DAOKO ft. 米津玄師", "daoko feat. 米津玄師"},
-		{"DAOKO Ft 米津玄師", "daoko feat. 米津玄師"},
-		{"DAOKO featuring 米津玄師", "daoko feat. 米津玄師"},
+		{"DAOKO ft. 米津玄師", "daoko 米津玄師"},
+		{"DAOKO Ft 米津玄師", "daoko 米津玄師"},
+		{"DAOKO featuring 米津玄師", "daoko 米津玄師"},
 		{"a   b\tc", "a b c"},
+		// Halfwidth/fullwidth katakana
+		{"ﾐｭｰｼﾞｯｸ", "ミュージック"},
+		{"ﾐｭｰｼﾞｯｸ", Normalize("ミュージック")},
+		{"ｻｶﾅｸｼｮﾝ", "サカナクション"},
+		// Fullwidth ASCII
+		{"ＤＡＯＫＯ", "daoko"},
+		// Quotes / punctuation
+		{`"HEROES"`, "heroes"},
+		{`"... AND I KEPT HEARING"`, "i kept hearing"},
+		{`"...AND I KEPT HEARING"`, "i kept hearing"},
+		{`"MA-MA" FC`, "ma ma fc"},
+		{`"MA-MA"FC`, "ma ma fc"},
+		// Artist separators: AND / & / / / , / +
+		{"BALLAKE SISSOKO AND VINCENT SEGAL", "ballake sissoko vincent segal"},
+		{"BALLAKE SISSOKO/VINCENT SEGAL", "ballake sissoko vincent segal"},
+		{"BALLAKE SISSOKO & VINCENT SEGAL", "ballake sissoko vincent segal"},
+		{"BALLAKE SISSOKO, VINCENT SEGAL", "ballake sissoko vincent segal"},
+		// "and" word boundary protection
+		{"land", "land"},
+		{"candy", "candy"},
+		// Curly quotes / dashes
+		{"It’s a test", "it s a test"},
+		{"foo—bar", "foo bar"},
+		// Zero-width / BOM / soft hyphen — silently dropped
+		{"\u200Byesterday", "yesterday"},
+		{"yesterday\u200B", "yesterday"},
+		{"yes\u200Bterday", "yesterday"},
+		{"\uFEFFyesterday", "yesterday"},
+		{"yes\u00ADterday", "yesterday"},
+		{"\u200Dyester\u200Cday\u200D", "yesterday"},
 	}
 	for _, c := range cases {
 		got := Normalize(c.in)
@@ -36,6 +66,20 @@ func TestDisplayClean(t *testing.T) {
 		{"Yesterday (2009 Remaster)", "Yesterday"},
 		{"曲名(生演奏)", "曲名"},
 		{"  曲名  ", "曲名"},
+		// Outer quotes get unwrapped
+		{`"HEROES"`, "HEROES"},
+		{`'HEROES'`, "HEROES"},
+		{"“HEROES”", "HEROES"},
+		{"‘HEROES’", "HEROES"},
+		{`"YOU'RE THE BEST PERSON IN THIS WORLD"`, "YOU'RE THE BEST PERSON IN THIS WORLD"},
+		// Mismatched quotes — left alone
+		{`"HEROES`, `"HEROES`},
+		{`HEROES"`, `HEROES"`},
+		{`"HEROES'`, `"HEROES'`},
+		// Invisible chars at start/end stripped
+		{"\u200BYesterday\u200B", "Yesterday"},
+		{"\uFEFFYesterday", "Yesterday"},
+		{"Yes\u200Bterday", "Yesterday"},
 	}
 	for _, c := range cases {
 		got := DisplayClean(c.in)
@@ -53,5 +97,26 @@ func TestSongIDStability(t *testing.T) {
 	c := SongID("yesterday  ", " The Beatles ")
 	if a != b || b != c {
 		t.Errorf("SongID variants do not match: %s %s %s", a, b, c)
+	}
+
+	// halfwidth/fullwidth + separator should also collapse
+	d := SongID("ミュージック", "サカナクション")
+	e := SongID("ﾐｭｰｼﾞｯｸ", "ｻｶﾅｸｼｮﾝ")
+	if d != e {
+		t.Errorf("kana variants do not match: %s %s", d, e)
+	}
+
+	f := SongID(`"MA-MA" FC`, "BALLAKE SISSOKO AND VINCENT SEGAL")
+	g := SongID(`"MA-MA"FC`, "BALLAKE SISSOKO/VINCENT SEGAL")
+	h := SongID(`"MA-MA" FC`, "BALLAKE SISSOKO & VINCENT SEGAL")
+	if f != g || g != h {
+		t.Errorf("punct/separator variants do not match: %s %s %s", f, g, h)
+	}
+
+	// Invisible chars must not break stability.
+	x := SongID("Yesterday", "The Beatles")
+	y := SongID("\u200BYesterday\u200B", "\uFEFFThe Beatles")
+	if x != y {
+		t.Errorf("invisible char variants do not match: %s %s", x, y)
 	}
 }

--- a/notify.go
+++ b/notify.go
@@ -23,21 +23,33 @@ func Notify(ctx context.Context, e event.Event) error {
 		app.LogError(err)
 		return err
 	}
-	var songs []Song
-	if err := json.Unmarshal(msg.Message.Data, &songs); err != nil {
+	var plays []PublishedPlay
+	if err := json.Unmarshal(msg.Message.Data, &plays); err != nil {
 		app.LogError(err)
 		return err
 	}
 
-	for _, song := range songs {
-		timeStr := (*song.Time).Format("2006/01/02 15:04")
-		fallback := fmt.Sprintf("%s %s / %s", timeStr, song.Title, song.Artist)
-		ts := (*song.Time).Unix()
+	for _, item := range plays {
+		t := item.Play.Time
+		if t == nil {
+			continue
+		}
+		title := item.Song.Title
+		artist := item.Song.Artist
+		if title == "" {
+			title = item.Play.RawTitle
+		}
+		if artist == "" {
+			artist = item.Play.RawArtist
+		}
+		timeStr := t.Format("2006/01/02 15:04")
+		fallback := fmt.Sprintf("%s %s / %s", timeStr, title, artist)
+		ts := t.Unix()
 
 		attachment1 := slack.Attachment{}
 		attachment1.Fallback = &fallback
-		attachment1.AuthorName = &song.Artist
-		attachment1.Title = &song.Title
+		attachment1.AuthorName = &artist
+		attachment1.Title = &title
 		attachment1.Timestamp = &ts
 		payload := slack.Payload{
 			Attachments: []slack.Attachment{attachment1},

--- a/song.go
+++ b/song.go
@@ -2,8 +2,21 @@ package onairlogsync
 
 import "time"
 
+// Song is a canonical airplay subject identified by the normalized
+// (title, artist) pair. Multiple Plays reference the same Song.
 type Song struct {
-	Time   *time.Time `firestore:"time" json:"time"`
-	Artist string     `firestore:"artist" json:"artist"`
-	Title  string     `firestore:"title" json:"title"`
+	Title         string     `firestore:"title" json:"title"`
+	Artist        string     `firestore:"artist" json:"artist"`
+	NormalizedKey string     `firestore:"normalizedKey" json:"-"`
+	FirstAired    *time.Time `firestore:"firstAired" json:"firstAired"`
+	LastAired     *time.Time `firestore:"lastAired" json:"lastAired"`
+	PlayCount     int        `firestore:"playCount" json:"playCount"`
+}
+
+// Play is a single airplay event and references a Song by ID.
+type Play struct {
+	SongID    string     `firestore:"songId" json:"songId"`
+	Time      *time.Time `firestore:"time" json:"time"`
+	RawTitle  string     `firestore:"rawTitle" json:"rawTitle"`
+	RawArtist string     `firestore:"rawArtist" json:"rawArtist"`
 }

--- a/sync.go
+++ b/sync.go
@@ -16,9 +16,9 @@ func init() {
 func Sync(ctx context.Context, e event.Event) error {
 	app := NewApp(ctx)
 	defer app.Close()
-	last := app.LastSong()
+	last := app.LastPlay()
 	if last == nil || last.Time == nil {
-		log.Println("No previous song found in Firestore; skipping sync")
+		log.Println("No previous play found in Firestore; skipping sync")
 		return nil
 	}
 	fmt.Println(*last.Time)


### PR DESCRIPTION
1 オンエア = 1 ドキュメントの構造をやめ、**「楽曲マスター (`songs`)」と「オンエア履歴 (`plays`)」** の 2 コレクション構成にします。これで「同じ曲が何回流れたか」「初出はいつか」といったクエリが自然に書けます。

## データモデル

```
songs/{songId}
  title:         "Yesterday"            # 表示用 (括弧除去・トリム)
  artist:        "The Beatles"
  normalizedKey: "yesterday|the beatles"
  firstAired:    timestamp
  lastAired:     timestamp
  playCount:     342

plays/{playId}
  songId:    "abc123..."                # → songs/{songId}
  time:      timestamp
  rawTitle:  "YESTERDAY (2009 REMASTER)"  # 原文保存
  rawArtist: "THE BEATLES"
```

- `songId = sha1(normalizedTitle | normalizedArtist)`
- `playId = sha1(unix_time | rawTitle | rawArtist)` — raw 行と 1:1 対応するので、将来 normalize ルールが変わっても play doc は再書き換え不要

## 正規化ルール

1. **Unicode NFKC** (半角カナ→全角、全角英数→半角)
2. `()` / `[]` / `（）` / `［］` の中身を除去 (例: `(生演奏)`, `(2009 Remaster)`)
3. 小文字化
4. `feat.` / `ft.` / `featuring` を空白扱い (区切り)
5. アーティスト区切り `&` / `+` / `,` / `/` / ` and ` を空白扱い
6. その他の句読点を空白扱い (Unicode 文字種でフィルタ、CJK 保持)
7. 不可視文字 (BOM, ゼロ幅, ソフトハイフン, 制御文字) を除去
8. 連続空白を 1 つに圧縮

`DisplayClean` は外側のクォート (`"..."` `'...'` `“...”` `‘...’`) もアンクオートします。

ユニットテスト同梱 (`normalize_test.go`)。

## 実装

- **`InsertPlay`**: play を `Create` (重複時は `AlreadyExists` で skip)、続いて song を transaction で upsert (`firstAired = min`, `lastAired = max`, `playCount += 1`)
- **`Sync`**: `LastPlay` で再開時刻を取得
- **`Notify`**: 通知ペイロードに `{play, song}` を含めて Slack に canonical な title/artist を表示
- **migrate**: 2 段構成:
  - `--prep` (Phase 1): MySQL の raw `songs` を読んで、新規 `csongs` / `plays` テーブルを集計付きで構築 (`INSERT ... ON DUPLICATE KEY UPDATE` で aggregation を DB 任せ、メモリ一定)
  - default (Phase 2): MySQL `csongs` / `plays` から Firestore へ流し込み
  - `--reset`: Firestore の `songs`/`plays` を一括削除
- **Firestore indexes**: `(songId asc, time desc)` 複合インデックスを追加。`plays.rawTitle/rawArtist`, `songs.normalizedKey` の単一インデックスを除外。
- **CI**: `.github/workflows/test.yml` で push (master/ci) / PR ごとに `go test ./...` 実行

## マージ前にユーザー側で必要な作業

```sh
# 既存の Firestore データをクリア
cd migrate
go run . --reset

# MySQL 内で正規化 + 集計
go run . --prep

# Firestore に流し込み
go run .
```

## API 連携

`onairlog-api` も互換性なしで合わせて変更しています: https://github.com/ngs/onairlog-api/pull/4

## Test plan

- [x] `go test ./...` (`TestNormalize` 41 ケース、`TestDisplayClean` 12 ケース、`TestSongIDStability` 4 グループ、すべて PASS)
- [x] CI 通過 (Build and test)
- [ ] フル移行後、`csongs` / `plays` の件数が想定通りか確認
- [ ] デプロイ後、新着曲が plays に追加され、対応する song の playCount が増えていく