### PR TITLE
Enrich songs via iTunes Search + Vertex AI Gemini

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,23 @@ ID は決定論的: `songId = sha1(normTitle | normArtist)`、`playId = sha1(uni
 
 | 変数 | 用途 |
 |---|---|
-| `PROJECT_ID` | GCP プロジェクト ID (Firestore / Pub/Sub / Error Reporting) |
+| `PROJECT_ID` | GCP プロジェクト ID (Firestore / Pub/Sub / Error Reporting / Vertex AI) |
 | `FIRESTORE_DATABASE` | Firestore データベース名 (省略時は `(default)`、本番では `onairlog`) |
 | `SLACK_WEBHOOK_URL` | Slack Incoming Webhook (Notify 関数のみ) |
+
+## エンリッチメント
+
+Sync は新着曲を Firestore に書き込んだ後、Song doc が未エンリッチ (または `enrichedAt` が 30 日以上前) ならば、iTunes Search API + Vertex AI Gemini Flash Lite で正規表記を補完します。失敗時は警告ログだけ出して Sync 自体は成功します。
+
+ランタイム SA に **`roles/aiplatform.user`** が必要です:
+
+```sh
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:$SERVICE_ACCOUNT_EMAIL" \
+  --role="roles/aiplatform.user"
+```
+
+Vertex AI のロケーションは `global`、モデルは `gemini-3.1-flash-lite` (GA)。
 
 ## ローカル実行
 

--- a/app.go
+++ b/app.go
@@ -183,7 +183,40 @@ func (app *App) InsertPlay(airTime *time.Time, rawTitle, rawArtist string) (*Pla
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// Best-effort enrichment via iTunes + Gemini. Failures are logged
+	// but do not fail the InsertPlay call.
+	if app.shouldEnrich(&resultSong) {
+		if er, err := app.Enrich(app.Context, rawTitle, rawArtist); err != nil {
+			app.LogError(fmt.Errorf("enrich %s/%s: %w", rawTitle, rawArtist, err))
+		} else {
+			now := time.Now().UTC()
+			resultSong.EnrichedAt = &now
+			resultSong.ITunesTrackID = er.ITunesTrackID
+			resultSong.CanonicalTitle = er.CanonicalTitle
+			resultSong.CanonicalArtist = er.CanonicalArtist
+			resultSong.CanonicalKey = er.CanonicalKey
+			resultSong.ITunesResponse = er.ITunesResponse
+			resultSong.LLMResponse = er.LLMResponse
+			if _, err := songRef.Set(app.Context, resultSong); err != nil {
+				app.LogError(fmt.Errorf("persist enrichment %s: %w", songID, err))
+			}
+		}
+	}
+
 	return &play, &resultSong, nil
+}
+
+// shouldEnrich returns true when the song has never been enriched or
+// when its last enrichment is older than enrichmentFreshness.
+func (app *App) shouldEnrich(s *Song) bool {
+	if s == nil {
+		return false
+	}
+	if s.EnrichedAt == nil {
+		return true
+	}
+	return time.Since(*s.EnrichedAt) > enrichmentFreshness
 }
 
 func (app *App) Visit(date time.Time) bool {

--- a/enrichment.go
+++ b/enrichment.go
@@ -1,0 +1,249 @@
+package onairlogsync
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"golang.org/x/oauth2/google"
+)
+
+// Vertex AI model used for the verification step. gemini-3.1-flash-lite
+// is the cheapest GA model and is good enough for "is candidate X the
+// same song as the input?" type judgements.
+const vertexModel = "gemini-3.1-flash-lite"
+
+// Default freshness window — songs enriched more recently than this are
+// not re-enriched on subsequent airplays. 30 days lets us pick up new
+// canonical info as it appears in iTunes without hammering the API.
+const enrichmentFreshness = 30 * 24 * time.Hour
+
+// EnrichmentResult is what the pipeline produces for one (rawTitle,
+// rawArtist) pair.
+type EnrichmentResult struct {
+	ITunesTrackID   int64
+	CanonicalTitle  string
+	CanonicalArtist string
+	CanonicalKey    string
+	Confidence      float64
+	ITunesResponse  map[string]interface{}
+	LLMResponse     map[string]interface{}
+}
+
+// Enrich consults the iTunes Search API and Gemini Flash to resolve a
+// raw (title, artist) pair to a canonical form. Failures are
+// non-fatal; the caller decides whether to persist whatever partial
+// result came back.
+func (app *App) Enrich(ctx context.Context, rawTitle, rawArtist string) (*EnrichmentResult, error) {
+	itunesRaw, candidates, err := iTunesSearch(ctx, rawTitle, rawArtist)
+	if err != nil {
+		return nil, fmt.Errorf("itunes search: %w", err)
+	}
+
+	verdict, llmRaw, err := app.geminiVerify(ctx, rawTitle, rawArtist, candidates)
+	if err != nil {
+		return nil, fmt.Errorf("gemini verify: %w", err)
+	}
+
+	res := &EnrichmentResult{
+		ITunesResponse: itunesRaw,
+		LLMResponse:    llmRaw,
+	}
+	if v := verdict["trackId"]; v != nil {
+		switch tv := v.(type) {
+		case float64:
+			res.ITunesTrackID = int64(tv)
+		case string:
+			if n, err := strconv.ParseInt(tv, 10, 64); err == nil {
+				res.ITunesTrackID = n
+			}
+		}
+	}
+	if s, _ := verdict["canonicalTitle"].(string); s != "" {
+		res.CanonicalTitle = s
+	}
+	if s, _ := verdict["canonicalArtist"].(string); s != "" {
+		res.CanonicalArtist = s
+	}
+	if c, ok := verdict["confidence"].(float64); ok {
+		res.Confidence = c
+	}
+
+	// Canonical key: prefer the verified iTunes track id, fall back to
+	// the canonical (title, artist) hash so soft-link merging still
+	// has something to group on for tracks iTunes can't identify.
+	switch {
+	case res.ITunesTrackID > 0:
+		res.CanonicalKey = "itunes:" + strconv.FormatInt(res.ITunesTrackID, 10)
+	case res.CanonicalTitle != "" && res.CanonicalArtist != "":
+		h := sha1.New()
+		fmt.Fprintf(h, "%s\x00%s", Normalize(res.CanonicalTitle), Normalize(res.CanonicalArtist))
+		res.CanonicalKey = "name:" + hex.EncodeToString(h.Sum(nil))
+	}
+	return res, nil
+}
+
+// iTunesSearch returns the raw response (for archival) and a parsed
+// candidate list (for the LLM prompt).
+func iTunesSearch(ctx context.Context, title, artist string) (map[string]interface{}, []map[string]interface{}, error) {
+	q := url.Values{
+		"term":    {title + " " + artist},
+		"country": {"jp"},
+		"media":   {"music"},
+		"entity":  {"song"},
+		"limit":   {"5"},
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		"https://itunes.apple.com/search?"+q.Encode(), nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	cli := &http.Client{Timeout: 10 * time.Second}
+	resp, err := cli.Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp.StatusCode != 200 {
+		return nil, nil, fmt.Errorf("itunes status %d: %s", resp.StatusCode, body)
+	}
+	var raw map[string]interface{}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, nil, err
+	}
+	results, _ := raw["results"].([]interface{})
+	cands := make([]map[string]interface{}, 0, len(results))
+	for _, r := range results {
+		if m, ok := r.(map[string]interface{}); ok {
+			cands = append(cands, map[string]interface{}{
+				"trackId":        m["trackId"],
+				"trackName":      m["trackName"],
+				"artistName":     m["artistName"],
+				"collectionName": m["collectionName"],
+			})
+		}
+	}
+	raw["queriedAt"] = time.Now().UTC().Format(time.RFC3339)
+	return raw, cands, nil
+}
+
+func (app *App) geminiVerify(ctx context.Context, rawTitle, rawArtist string, candidates []map[string]interface{}) (map[string]interface{}, map[string]interface{}, error) {
+	candJSON, _ := json.MarshalIndent(candidates, "", "  ")
+	prompt := fmt.Sprintf(
+		"You match a raw radio playlog entry to one of the iTunes candidates if and only if they refer to the same recording (or the same song; album/version differences are OK). "+
+			"Account for typos, the U+FFFD replacement char, abbreviations like II/2, hiragana/katakana variation, "+
+			"and English/Japanese transliteration of artist names (e.g. ALETHA FRANKLIN ↔ アレサ・フランクリン).\n\n"+
+			"INPUT raw_title : %q\n"+
+			"INPUT raw_artist: %q\n\n"+
+			"CANDIDATES (JSON):\n%s\n\n"+
+			`Reply with strict JSON only: {"trackId": <int or null>, "canonicalTitle": "<string or null>", "canonicalArtist": "<string or null>", "confidence": <0..1>, "reason": "<short>"}.`+"\n"+
+			"If none match, set trackId=null but still fill canonicalTitle/canonicalArtist with your best guess of the correct surface form.",
+		rawTitle, rawArtist, string(candJSON),
+	)
+
+	body := map[string]interface{}{
+		"contents": []map[string]interface{}{
+			{"role": "user", "parts": []map[string]interface{}{{"text": prompt}}},
+		},
+		"generationConfig": map[string]interface{}{
+			"responseMimeType": "application/json",
+			"temperature":      0,
+		},
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, nil, err
+	}
+	respBody, err := app.callVertexAI(ctx, payload)
+	if err != nil {
+		return nil, nil, err
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, nil, fmt.Errorf("decode vertex resp: %w; body=%s", err, respBody)
+	}
+
+	verdict := extractVerdict(resp)
+	llmArchive := map[string]interface{}{
+		"queriedAt": time.Now().UTC().Format(time.RFC3339),
+		"model":     vertexModel,
+		"verdict":   verdict,
+	}
+	if u, ok := resp["usageMetadata"].(map[string]interface{}); ok {
+		llmArchive["usageMetadata"] = u
+	}
+	return verdict, llmArchive, nil
+}
+
+func extractVerdict(resp map[string]interface{}) map[string]interface{} {
+	cands, _ := resp["candidates"].([]interface{})
+	if len(cands) == 0 {
+		return nil
+	}
+	c, _ := cands[0].(map[string]interface{})
+	content, _ := c["content"].(map[string]interface{})
+	parts, _ := content["parts"].([]interface{})
+	if len(parts) == 0 {
+		return nil
+	}
+	p0, _ := parts[0].(map[string]interface{})
+	text, _ := p0["text"].(string)
+	if text == "" {
+		return nil
+	}
+	var v map[string]interface{}
+	if err := json.Unmarshal([]byte(text), &v); err != nil {
+		return map[string]interface{}{"_raw": text}
+	}
+	return v
+}
+
+func (app *App) callVertexAI(ctx context.Context, payload []byte) ([]byte, error) {
+	ts, err := google.DefaultTokenSource(ctx, "https://www.googleapis.com/auth/cloud-platform")
+	if err != nil {
+		return nil, fmt.Errorf("token source: %w", err)
+	}
+	tok, err := ts.Token()
+	if err != nil {
+		return nil, fmt.Errorf("token: %w", err)
+	}
+
+	endpoint := fmt.Sprintf(
+		"https://aiplatform.googleapis.com/v1/projects/%s/locations/global/publishers/google/models/%s:generateContent",
+		app.ProjectID(), vertexModel,
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+	req.Header.Set("X-Goog-User-Project", app.ProjectID())
+	req.Header.Set("Content-Type", "application/json")
+
+	cli := &http.Client{Timeout: 30 * time.Second}
+	resp, err := cli.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("vertex status %d: %s", resp.StatusCode, body)
+	}
+	return body, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/ashwanthkumar/slack-go-webhook v0.0.0-20200209025033-430dd4e66960
 	github.com/cloudevents/sdk-go/v2 v2.14.0
 	github.com/gocolly/colly v1.2.0
+	golang.org/x/oauth2 v0.13.0
 	golang.org/x/text v0.35.0
 	google.golang.org/api v0.149.0
 	google.golang.org/grpc v1.59.0
@@ -52,7 +53,6 @@ require (
 	go.uber.org/zap v1.10.0 // indirect
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
-	golang.org/x/oauth2 v0.13.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/time v0.3.0 // indirect

--- a/song.go
+++ b/song.go
@@ -11,6 +11,16 @@ type Song struct {
 	FirstAired    *time.Time `firestore:"firstAired" json:"firstAired"`
 	LastAired     *time.Time `firestore:"lastAired" json:"lastAired"`
 	PlayCount     int        `firestore:"playCount" json:"playCount"`
+
+	// Enrichment fields, populated by the iTunes Search API + Gemini
+	// verification pipeline. Optional.
+	EnrichedAt      *time.Time             `firestore:"enrichedAt,omitempty" json:"enrichedAt,omitempty"`
+	ITunesTrackID   int64                  `firestore:"itunesTrackId,omitempty" json:"itunesTrackId,omitempty"`
+	CanonicalTitle  string                 `firestore:"canonicalTitle,omitempty" json:"canonicalTitle,omitempty"`
+	CanonicalArtist string                 `firestore:"canonicalArtist,omitempty" json:"canonicalArtist,omitempty"`
+	CanonicalKey    string                 `firestore:"canonicalKey,omitempty" json:"canonicalKey,omitempty"`
+	ITunesResponse  map[string]interface{} `firestore:"itunesResponse,omitempty" json:"-"`
+	LLMResponse     map[string]interface{} `firestore:"llmResponse,omitempty" json:"-"`
 }
 
 // Play is a single airplay event and references a Song by ID.


### PR DESCRIPTION
新着曲が Firestore に書き込まれるたび、**iTunes Search API + Vertex AI Gemini (gemini-3.1-flash-lite)** で正規表記を補完します。

## パイプライン

```
新着 play 検出
  ↓
song を upsert (firstAired/lastAired/playCount 更新)
  ↓
shouldEnrich(song)? (enrichedAt 未設定 or 30 日以上前)
  ↓ yes
iTunes Search に raw_title + raw_artist を投げ、上位 5 件を取得
  ↓
Gemini Flash Lite に「raw input は候補のどれと一致するか?」を JSON で問い合わせ
  ↓
verdict = {trackId, canonicalTitle, canonicalArtist, confidence, reason}
  ↓
song doc に enrichedAt / itunesTrackId / canonicalTitle / canonicalArtist /
canonicalKey / itunesResponse (raw) / llmResponse (raw) を書き込み
```

`canonicalKey` は名寄せのキーになる予定:
- iTunes でヒットした場合: `itunes:<trackId>`
- LLM のみで補完した場合: `name:<sha1(canonicalTitle | canonicalArtist)>`

## 検証済みケース

事前に curl ベースで確認 (詳細は別チャットログ):

| 入力 | 結果 |
|---|---|
| `ALETHA FRANKLIN / A ROSE...` (タイポ) | trackId 258594393, canonical "Aretha Franklin" / "A Rose Is Still a Rose" |
| `BOYZ�MEN / 4 SEASONS OF LONELINESS` (エンコード破損) | trackId 1444047057, canonical "Boyz II Men" |
| `HARD CHANGER / PORNO FOR PYROS` (ヒット 0 + ソース側タイポ) | trackId null, canonical "Hard Charger" / "Porno for Pyros" (LLM 補完) |
| `CLOCK SYMPHONY NO.101 / SOLTI` (クラシック、誤候補) | trackId null, canonical "Symphony No. 101 'The Clock'" / "Georg Solti & LPO" |
| 平仮名/片仮名混在 | 同じ canonical title に収束 |

## コスト試算

- iTunes Search: 無料
- Gemini 3.1 Flash Lite (Vertex AI, location=global):
  - 1 件あたり ~500 入力 + ~80 出力 token = **~$0.0001**
  - 月間想定 (1 日 ~500 新着 × 30 = 15,000 件): **~$1.5/月**
- 30 日 freshness window で再エンリッチを抑制

## マージ前にユーザー側で必要な作業

ランタイム SA に Vertex AI 権限を付与:

```sh
gcloud projects add-iam-policy-binding $PROJECT_ID \
  --member="serviceAccount:$SERVICE_ACCOUNT_EMAIL" \
  --role="roles/aiplatform.user"
```

(対応済み: `onairlog@onairlog.iam.gserviceaccount.com` に付与済み)

## 注意

- enrichment 失敗は警告ログを出して InsertPlay は成功扱い (Slack 通知は止めない)
- iTunes / Vertex AI のレイテンシ追加分でも Cloud Functions Gen 2 のタイムアウトには余裕あり
- raw レスポンスは Firestore に保存 (`itunesResponse` / `llmResponse`)。後で別パイプラインに食わせる時に使える

## 別 PR で対応する範囲

- 既存 512K 既存 song の一括エンリッチ (今回はオンデマンドのみ。新着 + 再放送で徐々に充実)
- `mergedInto` フィールドによる名寄せ (canonicalKey が同じ song を 1 つに集約)
- API 側で `canonicalTitle` を優先表示

## Test plan

- [x] `go build ./...` / `go vet ./...` / `go test ./...`
- [ ] デプロイ後、Sync ログに enrichment 結果が出力される
- [ ] Firestore Console で song doc に `canonicalTitle` / `itunesTrackId` 等が入る
- [ ] エラーケース (アクセス権なし等) でも Slack 通知は止まらない