### PR TITLE
Use canonical title/artist + iTunes link/artwork in Slack notify

### DIFF
--- a/notify.go
+++ b/notify.go
@@ -34,8 +34,9 @@ func Notify(ctx context.Context, e event.Event) error {
 		if t == nil {
 			continue
 		}
-		title := item.Song.Title
-		artist := item.Song.Artist
+		song := item.Song
+		title := song.DisplayTitle()
+		artist := song.DisplayArtist()
 		if title == "" {
 			title = item.Play.RawTitle
 		}
@@ -51,6 +52,12 @@ func Notify(ctx context.Context, e event.Event) error {
 		attachment1.AuthorName = &artist
 		attachment1.Title = &title
 		attachment1.Timestamp = &ts
+		if link := song.ITunesURL(); link != "" {
+			attachment1.TitleLink = &link
+		}
+		if art := song.ArtworkURL(); art != "" {
+			attachment1.ThumbnailUrl = &art
+		}
 		payload := slack.Payload{
 			Attachments: []slack.Attachment{attachment1},
 		}

--- a/notify.go
+++ b/notify.go
@@ -56,7 +56,7 @@ func Notify(ctx context.Context, e event.Event) error {
 			attachment1.TitleLink = &link
 		}
 		if art := song.ArtworkURL(); art != "" {
-			attachment1.ThumbnailUrl = &art
+			attachment1.ImageUrl = &art
 		}
 		payload := slack.Payload{
 			Attachments: []slack.Attachment{attachment1},

--- a/song.go
+++ b/song.go
@@ -1,6 +1,10 @@
 package onairlogsync
 
-import "time"
+import (
+	"fmt"
+	"strings"
+	"time"
+)
 
 // Song is a canonical airplay subject identified by the normalized
 // (title, artist) pair. Multiple Plays reference the same Song.
@@ -29,4 +33,55 @@ type Play struct {
 	Time      *time.Time `firestore:"time" json:"time"`
 	RawTitle  string     `firestore:"rawTitle" json:"rawTitle"`
 	RawArtist string     `firestore:"rawArtist" json:"rawArtist"`
+}
+
+// DisplayTitle prefers the canonical (enriched) title, falling back to
+// the raw display string captured at airplay time.
+func (s *Song) DisplayTitle() string {
+	if s == nil {
+		return ""
+	}
+	if s.CanonicalTitle != "" {
+		return s.CanonicalTitle
+	}
+	return s.Title
+}
+
+// DisplayArtist prefers the canonical (enriched) artist.
+func (s *Song) DisplayArtist() string {
+	if s == nil {
+		return ""
+	}
+	if s.CanonicalArtist != "" {
+		return s.CanonicalArtist
+	}
+	return s.Artist
+}
+
+// ITunesURL returns the music.apple.com URL for the verified track,
+// or an empty string when the song has no iTunes match.
+func (s *Song) ITunesURL() string {
+	if s == nil || s.ITunesTrackID == 0 {
+		return ""
+	}
+	return fmt.Sprintf("https://music.apple.com/jp/song/%d", s.ITunesTrackID)
+}
+
+// ArtworkURL extracts the cover art URL from the archived iTunes
+// response and upscales it to 600x600. Returns an empty string when
+// no artwork is available.
+func (s *Song) ArtworkURL() string {
+	if s == nil || s.ITunesResponse == nil {
+		return ""
+	}
+	results, _ := s.ITunesResponse["results"].([]interface{})
+	if len(results) == 0 {
+		return ""
+	}
+	r0, _ := results[0].(map[string]interface{})
+	u, _ := r0["artworkUrl100"].(string)
+	if u == "" {
+		return ""
+	}
+	return strings.ReplaceAll(u, "100x100bb", "600x600bb")
 }


### PR DESCRIPTION
Slack 通知に enrichment 結果を反映します。

## 表示の変化

**Before** (raw のみ):
```
BOYZ�MEN
 4 SEASONS OF LONELYNESS
 2026/05/08 12:34
```

**After** (canonical + アートワーク + リンク):
```
[アートワーク 600x600]  Boyz II Men
                        4 Seasons of Loneliness   ← クリックで Apple Music
                        2026/05/08 12:34
```

## 実装

- `Song.DisplayTitle()` / `DisplayArtist()` で canonical 優先 (raw フォールバック)
- `Song.ITunesURL()` → `https://music.apple.com/jp/song/<trackId>`
- `Song.ArtworkURL()` → iTunes raw レスポンスから artwork URL を抽出、`100x100bb` → `600x600bb` にアップスケール
- Slack `Attachment.TitleLink` / `ThumbnailUrl` に設定

未 enrich の song はこれまで通り raw 表記。enrichment 完了後に自動でリッチ表示に切り替わります。

## API 側 PR

https://github.com/ngs/onairlog-api/pull/5

## Test plan

- [x] `go build ./...` / `go test ./...`
- [ ] デプロイ後、新着曲の Slack 通知に canonical 表記 + アートワーク + リンクが表示される
- [ ] enrichment が未完の song は従来表示にフォールバックする