### PR TITLE
Slack notify: footer with HH:MM + persisted artwork/iTunes URL fields

### DIFF
--- a/app.go
+++ b/app.go
@@ -196,6 +196,8 @@ func (app *App) InsertPlay(airTime *time.Time, rawTitle, rawArtist string) (*Pla
 			resultSong.CanonicalTitle = er.CanonicalTitle
 			resultSong.CanonicalArtist = er.CanonicalArtist
 			resultSong.CanonicalKey = er.CanonicalKey
+			resultSong.ITunesURL = er.ITunesURL
+			resultSong.ArtworkURL = er.ArtworkURL
 			resultSong.ITunesResponse = er.ITunesResponse
 			resultSong.LLMResponse = er.LLMResponse
 			if _, err := songRef.Set(app.Context, resultSong); err != nil {

--- a/enrichment.go
+++ b/enrichment.go
@@ -34,6 +34,8 @@ type EnrichmentResult struct {
 	CanonicalArtist string
 	CanonicalKey    string
 	Confidence      float64
+	ITunesURL       string
+	ArtworkURL      string
 	ITunesResponse  map[string]interface{}
 	LLMResponse     map[string]interface{}
 }
@@ -56,6 +58,7 @@ func (app *App) Enrich(ctx context.Context, rawTitle, rawArtist string) (*Enrich
 	res := &EnrichmentResult{
 		ITunesResponse: itunesRaw,
 		LLMResponse:    llmRaw,
+		ArtworkURL:     ExtractArtworkURL(itunesRaw),
 	}
 	if v := verdict["trackId"]; v != nil {
 		switch tv := v.(type) {
@@ -88,6 +91,7 @@ func (app *App) Enrich(ctx context.Context, rawTitle, rawArtist string) (*Enrich
 		fmt.Fprintf(h, "%s\x00%s", Normalize(res.CanonicalTitle), Normalize(res.CanonicalArtist))
 		res.CanonicalKey = "name:" + hex.EncodeToString(h.Sum(nil))
 	}
+	res.ITunesURL = BuildITunesURL(res.ITunesTrackID)
 	return res, nil
 }
 

--- a/notify.go
+++ b/notify.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
 	"github.com/ashwanthkumar/slack-go-webhook"
@@ -43,7 +44,12 @@ func Notify(ctx context.Context, e event.Event) error {
 		if artist == "" {
 			artist = item.Play.RawArtist
 		}
-		timeStr := t.Format("2006/01/02 15:04")
+		jst, err := time.LoadLocation("Asia/Tokyo")
+		if err != nil {
+			app.LogError(err)
+			jst = time.UTC
+		}
+		timeStr := t.In(jst).Format("2006/01/02 15:04")
 		fallback := fmt.Sprintf("%s %s / %s", timeStr, title, artist)
 		ts := t.Unix()
 
@@ -51,6 +57,7 @@ func Notify(ctx context.Context, e event.Event) error {
 		attachment1.Fallback = &fallback
 		attachment1.AuthorName = &artist
 		attachment1.Title = &title
+		attachment1.Footer = &timeStr
 		attachment1.Timestamp = &ts
 		if link := song.ITunesURL(); link != "" {
 			attachment1.TitleLink = &link

--- a/notify.go
+++ b/notify.go
@@ -59,10 +59,12 @@ func Notify(ctx context.Context, e event.Event) error {
 		attachment1.Title = &title
 		attachment1.Footer = &timeStr
 		attachment1.Timestamp = &ts
-		if link := song.ITunesURL(); link != "" {
+		if song.ITunesURL != "" {
+			link := song.ITunesURL
 			attachment1.TitleLink = &link
 		}
-		if art := song.ArtworkURL(); art != "" {
+		if song.ArtworkURL != "" {
+			art := song.ArtworkURL
 			attachment1.ImageUrl = &art
 		}
 		payload := slack.Payload{

--- a/song.go
+++ b/song.go
@@ -23,8 +23,14 @@ type Song struct {
 	CanonicalTitle  string                 `firestore:"canonicalTitle,omitempty" json:"canonicalTitle,omitempty"`
 	CanonicalArtist string                 `firestore:"canonicalArtist,omitempty" json:"canonicalArtist,omitempty"`
 	CanonicalKey    string                 `firestore:"canonicalKey,omitempty" json:"canonicalKey,omitempty"`
-	ITunesResponse  map[string]interface{} `firestore:"itunesResponse,omitempty" json:"-"`
-	LLMResponse     map[string]interface{} `firestore:"llmResponse,omitempty" json:"-"`
+	// Pre-computed for downstream consumers (Notify, API) so they
+	// don't have to dig through ITunesResponse.
+	ArtworkURL  string                 `firestore:"artworkUrl,omitempty" json:"artworkUrl,omitempty"`
+	ITunesURL   string                 `firestore:"itunesUrl,omitempty" json:"itunesUrl,omitempty"`
+	// Raw archives — Firestore-only, intentionally excluded from JSON
+	// to keep Pub/Sub payloads small.
+	ITunesResponse map[string]interface{} `firestore:"itunesResponse,omitempty" json:"-"`
+	LLMResponse    map[string]interface{} `firestore:"llmResponse,omitempty" json:"-"`
 }
 
 // Play is a single airplay event and references a Song by ID.
@@ -58,23 +64,22 @@ func (s *Song) DisplayArtist() string {
 	return s.Artist
 }
 
-// ITunesURL returns the music.apple.com URL for the verified track,
-// or an empty string when the song has no iTunes match.
-func (s *Song) ITunesURL() string {
-	if s == nil || s.ITunesTrackID == 0 {
+// BuildITunesURL is the music.apple.com URL for a verified iTunes
+// track id, or an empty string when there is no match.
+func BuildITunesURL(trackID int64) string {
+	if trackID == 0 {
 		return ""
 	}
-	return fmt.Sprintf("https://music.apple.com/jp/song/%d", s.ITunesTrackID)
+	return fmt.Sprintf("https://music.apple.com/jp/song/%d", trackID)
 }
 
-// ArtworkURL extracts the cover art URL from the archived iTunes
-// response and upscales it to 600x600. Returns an empty string when
-// no artwork is available.
-func (s *Song) ArtworkURL() string {
-	if s == nil || s.ITunesResponse == nil {
+// ExtractArtworkURL pulls the 600x600 cover art URL out of an iTunes
+// search result map (the top hit). Returns "" when unavailable.
+func ExtractArtworkURL(itunes map[string]interface{}) string {
+	if itunes == nil {
 		return ""
 	}
-	results, _ := s.ITunesResponse["results"].([]interface{})
+	results, _ := itunes["results"].([]interface{})
 	if len(results) == 0 {
 		return ""
 	}

--- a/song_test.go
+++ b/song_test.go
@@ -1,0 +1,175 @@
+package onairlogsync
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSongJSONIncludesEnrichmentURLs(t *testing.T) {
+	// Regression: Slack notifications were missing artwork because the
+	// pre-computed URLs were not flowing through the Pub/Sub payload.
+	// They must round-trip via JSON so Notify can read them.
+	now := time.Now().UTC()
+	in := Song{
+		Title:           "YOU MIGHT THINK",
+		Artist:          "CARS",
+		PlayCount:       5,
+		FirstAired:      &now,
+		LastAired:       &now,
+		EnrichedAt:      &now,
+		ITunesTrackID:   1088528668,
+		CanonicalTitle:  "You Might Think",
+		CanonicalArtist: "The Cars",
+		CanonicalKey:    "itunes:1088528668",
+		ArtworkURL:      "https://example.com/artwork.jpg",
+		ITunesURL:       "https://music.apple.com/jp/song/1088528668",
+		ITunesResponse: map[string]interface{}{
+			"resultCount": 1,
+			"results":     []interface{}{},
+		},
+	}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	js := string(b)
+
+	want := []string{`"artworkUrl":"https://example.com/artwork.jpg"`,
+		`"itunesUrl":"https://music.apple.com/jp/song/1088528668"`,
+		`"canonicalTitle":"You Might Think"`,
+		`"canonicalArtist":"The Cars"`,
+		`"itunesTrackId":1088528668`}
+	for _, w := range want {
+		if !strings.Contains(js, w) {
+			t.Errorf("expected JSON to contain %s, got: %s", w, js)
+		}
+	}
+
+	// ITunesResponse / LLMResponse are intentionally excluded from JSON.
+	for _, w := range []string{`itunesResponse`, `llmResponse`} {
+		if strings.Contains(js, w) {
+			t.Errorf("expected JSON to omit %s, got: %s", w, js)
+		}
+	}
+
+	var out Song
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.ArtworkURL != in.ArtworkURL {
+		t.Errorf("ArtworkURL not preserved: %q vs %q", out.ArtworkURL, in.ArtworkURL)
+	}
+	if out.ITunesURL != in.ITunesURL {
+		t.Errorf("ITunesURL not preserved: %q vs %q", out.ITunesURL, in.ITunesURL)
+	}
+	if out.CanonicalTitle != in.CanonicalTitle || out.CanonicalArtist != in.CanonicalArtist {
+		t.Errorf("canonical not preserved: %+v", out)
+	}
+	if out.ITunesTrackID != in.ITunesTrackID {
+		t.Errorf("trackId not preserved: %d vs %d", out.ITunesTrackID, in.ITunesTrackID)
+	}
+}
+
+func TestPublishedPlayRoundTrip(t *testing.T) {
+	// The full Pub/Sub payload Sync emits and Notify consumes.
+	now := time.Now().UTC()
+	in := []PublishedPlay{{
+		Play: Play{
+			SongID:    "abc",
+			Time:      &now,
+			RawTitle:  "YOU MIGHT THINK",
+			RawArtist: "CARS",
+		},
+		Song: Song{
+			Title:           "YOU MIGHT THINK",
+			Artist:          "CARS",
+			CanonicalTitle:  "You Might Think",
+			CanonicalArtist: "The Cars",
+			ArtworkURL:      "https://example.com/art.jpg",
+			ITunesURL:       "https://music.apple.com/jp/song/1",
+			ITunesTrackID:   1,
+		},
+	}}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out []PublishedPlay
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("len = %d", len(out))
+	}
+	got := out[0]
+	if got.Song.ArtworkURL != "https://example.com/art.jpg" {
+		t.Errorf("ArtworkURL lost in round-trip: %q", got.Song.ArtworkURL)
+	}
+	if got.Song.ITunesURL != "https://music.apple.com/jp/song/1" {
+		t.Errorf("ITunesURL lost in round-trip: %q", got.Song.ITunesURL)
+	}
+	if got.Play.RawTitle != "YOU MIGHT THINK" {
+		t.Errorf("RawTitle lost: %q", got.Play.RawTitle)
+	}
+}
+
+func TestDisplayTitleArtist(t *testing.T) {
+	cases := []struct {
+		s              Song
+		wantTitle      string
+		wantArtist     string
+		descr          string
+	}{
+		{Song{Title: "RAW TITLE", Artist: "RAW ARTIST"}, "RAW TITLE", "RAW ARTIST", "no canonical"},
+		{Song{Title: "RAW", Artist: "RAW", CanonicalTitle: "Canonical T", CanonicalArtist: "Canonical A"}, "Canonical T", "Canonical A", "both canonical"},
+		{Song{Title: "RAW", Artist: "RAW", CanonicalTitle: "Canonical T"}, "Canonical T", "RAW", "title canonical only"},
+		{Song{Title: "RAW", Artist: "RAW", CanonicalArtist: "Canonical A"}, "RAW", "Canonical A", "artist canonical only"},
+	}
+	for _, c := range cases {
+		if got := c.s.DisplayTitle(); got != c.wantTitle {
+			t.Errorf("[%s] DisplayTitle = %q, want %q", c.descr, got, c.wantTitle)
+		}
+		if got := c.s.DisplayArtist(); got != c.wantArtist {
+			t.Errorf("[%s] DisplayArtist = %q, want %q", c.descr, got, c.wantArtist)
+		}
+	}
+}
+
+func TestBuildITunesURL(t *testing.T) {
+	if got := BuildITunesURL(0); got != "" {
+		t.Errorf("expected empty for trackID=0, got %q", got)
+	}
+	if got := BuildITunesURL(12345); got != "https://music.apple.com/jp/song/12345" {
+		t.Errorf("unexpected: %q", got)
+	}
+}
+
+func TestExtractArtworkURL(t *testing.T) {
+	cases := []struct {
+		in   map[string]interface{}
+		want string
+	}{
+		{nil, ""},
+		{map[string]interface{}{}, ""},
+		{map[string]interface{}{"results": []interface{}{}}, ""},
+		{
+			map[string]interface{}{"results": []interface{}{
+				map[string]interface{}{"artworkUrl100": "https://x/100x100bb.jpg"},
+			}},
+			"https://x/600x600bb.jpg",
+		},
+		{
+			map[string]interface{}{"results": []interface{}{
+				map[string]interface{}{}, // no artworkUrl100
+			}},
+			"",
+		},
+	}
+	for _, c := range cases {
+		if got := ExtractArtworkURL(c.in); got != c.want {
+			t.Errorf("ExtractArtworkURL(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## 1. footer に時分表示

\`ts\` フィールドは Slack が古い日付を「May 1st」のように日付のみに丸めるため、時分が見えない。footer 行に \`YYYY/MM/DD HH:MM\` (JST) を埋めて常時表示。

## 2. アートワークが Slack に届かないバグの修正

PR #8 で \`ArtworkURL()\` / \`ITunesURL()\` メソッドを実装したが、これらは \`ITunesResponse\` (json:\"-\") から計算するため、**Pub/Sub 経由で Notify に届くペイロードからは除外**されており、Slack 通知にアートワーク・リンクが付かなかった。

修正: enrichment 時に \`ArtworkURL\` と \`ITunesURL\` を **Song doc のフィールドとして保存** し、Pub/Sub にも載せる。Notify はフィールドを直接参照。

API 側にも対応 PR: https://github.com/ngs/onairlog-api/pull/6

## Test plan

- [x] \`go build\` / \`go test\`
- [ ] デプロイ後、新着 enrich 済み曲の Slack 通知にアートワーク + リンク + footer 時刻が出る