### PR TITLE
Extract InsertPlay helpers and pin publish payload contract

### DIFF
--- a/app.go
+++ b/app.go
@@ -123,6 +123,46 @@ func PlayDocID(airTime time.Time, rawTitle, rawArtist string) string {
 	return hex.EncodeToString(h.Sum(nil))
 }
 
+// BuildPlay constructs the Play document for a new airplay event.
+// Pure function — no Firestore dependency, suitable for testing the
+// publish payload assembly.
+func BuildPlay(airTime *time.Time, rawTitle, rawArtist string) Play {
+	return Play{
+		SongID:    SongID(rawTitle, rawArtist),
+		Time:      airTime,
+		RawTitle:  rawTitle,
+		RawArtist: rawArtist,
+	}
+}
+
+// NewSongFromPlay builds the canonical Song document the first time a
+// (rawTitle, rawArtist) is observed.
+func NewSongFromPlay(airTime *time.Time, rawTitle, rawArtist string) Song {
+	return Song{
+		Title:         DisplayClean(rawTitle),
+		Artist:        DisplayClean(rawArtist),
+		NormalizedKey: NormalizedKey(rawTitle, rawArtist),
+		FirstAired:    airTime,
+		LastAired:     airTime,
+		PlayCount:     1,
+	}
+}
+
+// ApplyPlay merges a new airplay into an existing Song's aggregate
+// fields and returns the updated Song. Pure function — does not mutate
+// existing.
+func ApplyPlay(existing Song, airTime *time.Time) Song {
+	updated := existing
+	if updated.FirstAired == nil || airTime.Before(*updated.FirstAired) {
+		updated.FirstAired = airTime
+	}
+	if updated.LastAired == nil || airTime.After(*updated.LastAired) {
+		updated.LastAired = airTime
+	}
+	updated.PlayCount++
+	return updated
+}
+
 // InsertPlay creates a Play and upserts the canonical Song it points to.
 // Returns (play, song, error). When the play already exists (same airtime
 // and song), play is nil to indicate "nothing new".
@@ -137,12 +177,7 @@ func (app *App) InsertPlay(airTime *time.Time, rawTitle, rawArtist string) (*Pla
 	playRef := app.Firestore().Collection(playsCollection).Doc(playID)
 	songRef := app.Firestore().Collection(songsCollection).Doc(songID)
 
-	play := Play{
-		SongID:    songID,
-		Time:      airTime,
-		RawTitle:  rawTitle,
-		RawArtist: rawArtist,
-	}
+	play := BuildPlay(airTime, rawTitle, rawArtist)
 
 	if _, err := playRef.Create(app.Context, play); err != nil {
 		if status.Code(err) == codes.AlreadyExists {
@@ -155,29 +190,17 @@ func (app *App) InsertPlay(airTime *time.Time, rawTitle, rawArtist string) (*Pla
 	err := app.Firestore().RunTransaction(app.Context, func(ctx context.Context, tx *firestore.Transaction) error {
 		snap, err := tx.Get(songRef)
 		if status.Code(err) == codes.NotFound {
-			resultSong = Song{
-				Title:         DisplayClean(rawTitle),
-				Artist:        DisplayClean(rawArtist),
-				NormalizedKey: NormalizedKey(rawTitle, rawArtist),
-				FirstAired:    airTime,
-				LastAired:     airTime,
-				PlayCount:     1,
-			}
+			resultSong = NewSongFromPlay(airTime, rawTitle, rawArtist)
 			return tx.Create(songRef, resultSong)
 		}
 		if err != nil {
 			return err
 		}
-		if err := snap.DataTo(&resultSong); err != nil {
+		var existing Song
+		if err := snap.DataTo(&existing); err != nil {
 			return err
 		}
-		if resultSong.FirstAired == nil || airTime.Before(*resultSong.FirstAired) {
-			resultSong.FirstAired = airTime
-		}
-		if resultSong.LastAired == nil || airTime.After(*resultSong.LastAired) {
-			resultSong.LastAired = airTime
-		}
-		resultSong.PlayCount++
+		resultSong = ApplyPlay(existing, airTime)
 		return tx.Set(songRef, resultSong)
 	})
 	if err != nil {

--- a/app.go
+++ b/app.go
@@ -196,6 +196,8 @@ func (app *App) InsertPlay(airTime *time.Time, rawTitle, rawArtist string) (*Pla
 			resultSong.CanonicalTitle = er.CanonicalTitle
 			resultSong.CanonicalArtist = er.CanonicalArtist
 			resultSong.CanonicalKey = er.CanonicalKey
+			resultSong.ITunesURL = er.ITunesURL
+			resultSong.ArtworkURL = er.ArtworkURL
 			resultSong.ITunesResponse = er.ITunesResponse
 			resultSong.LLMResponse = er.LLMResponse
 			if _, err := songRef.Set(app.Context, resultSong); err != nil {

--- a/enrichment.go
+++ b/enrichment.go
@@ -34,6 +34,8 @@ type EnrichmentResult struct {
 	CanonicalArtist string
 	CanonicalKey    string
 	Confidence      float64
+	ITunesURL       string
+	ArtworkURL      string
 	ITunesResponse  map[string]interface{}
 	LLMResponse     map[string]interface{}
 }
@@ -56,6 +58,7 @@ func (app *App) Enrich(ctx context.Context, rawTitle, rawArtist string) (*Enrich
 	res := &EnrichmentResult{
 		ITunesResponse: itunesRaw,
 		LLMResponse:    llmRaw,
+		ArtworkURL:     ExtractArtworkURL(itunesRaw),
 	}
 	if v := verdict["trackId"]; v != nil {
 		switch tv := v.(type) {
@@ -88,6 +91,7 @@ func (app *App) Enrich(ctx context.Context, rawTitle, rawArtist string) (*Enrich
 		fmt.Fprintf(h, "%s\x00%s", Normalize(res.CanonicalTitle), Normalize(res.CanonicalArtist))
 		res.CanonicalKey = "name:" + hex.EncodeToString(h.Sum(nil))
 	}
+	res.ITunesURL = BuildITunesURL(res.ITunesTrackID)
 	return res, nil
 }
 

--- a/enrichment.go
+++ b/enrichment.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"golang.org/x/oauth2/google"
@@ -58,7 +59,6 @@ func (app *App) Enrich(ctx context.Context, rawTitle, rawArtist string) (*Enrich
 	res := &EnrichmentResult{
 		ITunesResponse: itunesRaw,
 		LLMResponse:    llmRaw,
-		ArtworkURL:     ExtractArtworkURL(itunesRaw),
 	}
 	if v := verdict["trackId"]; v != nil {
 		switch tv := v.(type) {
@@ -80,6 +80,26 @@ func (app *App) Enrich(ctx context.Context, rawTitle, rawArtist string) (*Enrich
 		res.Confidence = c
 	}
 
+	// Hybrid fallback: when the LLM was uncertain (no trackId picked)
+	// but the iTunes top result's artist matches the LLM-derived
+	// canonical artist (after normalization), trust the top result.
+	// This recovers cases like "HEROIN / MAROON 5" where iTunes
+	// surfaces "Heroine / マルーン5" as the top hit but the LLM
+	// disagrees on the title because it differs by one letter.
+	if res.ITunesTrackID == 0 {
+		if topID, topArtist, topArtwork := topITunesHit(itunesRaw); topID > 0 &&
+			res.CanonicalArtist != "" && Normalize(topArtist) == Normalize(res.CanonicalArtist) {
+			res.ITunesTrackID = topID
+			res.ArtworkURL = topArtwork
+		}
+	}
+
+	if res.ArtworkURL == "" && res.ITunesTrackID > 0 {
+		// Pull artwork from the candidate that matches the verified
+		// trackId so the image always belongs to the linked track.
+		res.ArtworkURL = artworkForTrack(itunesRaw, res.ITunesTrackID)
+	}
+
 	// Canonical key: prefer the verified iTunes track id, fall back to
 	// the canonical (title, artist) hash so soft-link merging still
 	// has something to group on for tracks iTunes can't identify.
@@ -93,6 +113,64 @@ func (app *App) Enrich(ctx context.Context, rawTitle, rawArtist string) (*Enrich
 	}
 	res.ITunesURL = BuildITunesURL(res.ITunesTrackID)
 	return res, nil
+}
+
+// topITunesHit returns the trackId, artistName and 600x600 artworkUrl
+// of the first iTunes Search result, or zero values if missing.
+func topITunesHit(itunes map[string]interface{}) (int64, string, string) {
+	if itunes == nil {
+		return 0, "", ""
+	}
+	results, _ := itunes["results"].([]interface{})
+	if len(results) == 0 {
+		return 0, "", ""
+	}
+	r0, _ := results[0].(map[string]interface{})
+	var id int64
+	switch v := r0["trackId"].(type) {
+	case float64:
+		id = int64(v)
+	case string:
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil {
+			id = n
+		}
+	}
+	artist, _ := r0["artistName"].(string)
+	artwork, _ := r0["artworkUrl100"].(string)
+	if artwork != "" {
+		artwork = strings.ReplaceAll(artwork, "100x100bb", "600x600bb")
+	}
+	return id, artist, artwork
+}
+
+// artworkForTrack scans the iTunes results for the given trackId and
+// returns its 600x600 artwork URL. Falls back to the top result if the
+// id is not found (handy when LLM picks a differently-numbered match).
+func artworkForTrack(itunes map[string]interface{}, trackID int64) string {
+	if itunes == nil || trackID == 0 {
+		return ExtractArtworkURL(itunes)
+	}
+	results, _ := itunes["results"].([]interface{})
+	for _, r := range results {
+		rm, _ := r.(map[string]interface{})
+		var id int64
+		switch v := rm["trackId"].(type) {
+		case float64:
+			id = int64(v)
+		case string:
+			if n, err := strconv.ParseInt(v, 10, 64); err == nil {
+				id = n
+			}
+		}
+		if id == trackID {
+			u, _ := rm["artworkUrl100"].(string)
+			if u == "" {
+				return ""
+			}
+			return strings.ReplaceAll(u, "100x100bb", "600x600bb")
+		}
+	}
+	return ExtractArtworkURL(itunes)
 }
 
 // iTunesSearch returns the raw response (for archival) and a parsed

--- a/enrichment_test.go
+++ b/enrichment_test.go
@@ -1,0 +1,225 @@
+package onairlogsync
+
+import "testing"
+
+// itunesResultsFixture is the structural shape of `iTunesResponse`
+// stored on the Song doc — `results` is a slice of opaque maps.
+func itunesResultsFixture(rs ...map[string]interface{}) map[string]interface{} {
+	out := []interface{}{}
+	for _, r := range rs {
+		out = append(out, r)
+	}
+	return map[string]interface{}{"results": out}
+}
+
+func TestTopITunesHit(t *testing.T) {
+	itunes := itunesResultsFixture(
+		map[string]interface{}{
+			"trackId":       float64(6763663512),
+			"artistName":    "マルーン5",
+			"artworkUrl100": "https://example.com/100x100bb.jpg",
+		},
+		map[string]interface{}{
+			"trackId":    float64(2),
+			"artistName": "Other",
+		},
+	)
+	id, artist, artwork := topITunesHit(itunes)
+	if id != 6763663512 {
+		t.Errorf("id = %d, want 6763663512", id)
+	}
+	if artist != "マルーン5" {
+		t.Errorf("artist = %q", artist)
+	}
+	if artwork != "https://example.com/600x600bb.jpg" {
+		t.Errorf("artwork = %q", artwork)
+	}
+}
+
+func TestTopITunesHit_emptyResults(t *testing.T) {
+	id, artist, artwork := topITunesHit(map[string]interface{}{"results": []interface{}{}})
+	if id != 0 || artist != "" || artwork != "" {
+		t.Errorf("expected zero values, got %d %q %q", id, artist, artwork)
+	}
+}
+
+func TestArtworkForTrack_matchByID(t *testing.T) {
+	itunes := itunesResultsFixture(
+		map[string]interface{}{
+			"trackId":       float64(1),
+			"artworkUrl100": "https://wrong/100x100bb.jpg",
+		},
+		map[string]interface{}{
+			"trackId":       float64(42),
+			"artworkUrl100": "https://right/100x100bb.jpg",
+		},
+	)
+	got := artworkForTrack(itunes, 42)
+	if got != "https://right/600x600bb.jpg" {
+		t.Errorf("got %q, want match for trackId=42", got)
+	}
+}
+
+func TestArtworkForTrack_unknownIDFallsBackToTop(t *testing.T) {
+	itunes := itunesResultsFixture(
+		map[string]interface{}{
+			"trackId":       float64(1),
+			"artworkUrl100": "https://top/100x100bb.jpg",
+		},
+	)
+	got := artworkForTrack(itunes, 999)
+	if got != "https://top/600x600bb.jpg" {
+		t.Errorf("got %q, want top-result fallback", got)
+	}
+}
+
+// applyVerdictForTest re-implements the post-LLM logic of Enrich
+// (without making network calls) so we can verify the hybrid
+// fallback behavior against synthetic iTunes + verdict data.
+func applyVerdictForTest(itunesRaw map[string]interface{}, verdict map[string]interface{}) *EnrichmentResult {
+	res := &EnrichmentResult{
+		ITunesResponse: itunesRaw,
+	}
+	if v, ok := verdict["trackId"].(float64); ok {
+		res.ITunesTrackID = int64(v)
+	}
+	if s, _ := verdict["canonicalTitle"].(string); s != "" {
+		res.CanonicalTitle = s
+	}
+	if s, _ := verdict["canonicalArtist"].(string); s != "" {
+		res.CanonicalArtist = s
+	}
+	// Hybrid fallback (mirrors Enrich)
+	if res.ITunesTrackID == 0 {
+		if topID, topArtist, topArtwork := topITunesHit(itunesRaw); topID > 0 &&
+			res.CanonicalArtist != "" && Normalize(topArtist) == Normalize(res.CanonicalArtist) {
+			res.ITunesTrackID = topID
+			res.ArtworkURL = topArtwork
+		}
+	}
+	if res.ArtworkURL == "" && res.ITunesTrackID > 0 {
+		res.ArtworkURL = artworkForTrack(itunesRaw, res.ITunesTrackID)
+	}
+	res.ITunesURL = BuildITunesURL(res.ITunesTrackID)
+	return res
+}
+
+// TestEnrichHybrid_LLMNullButArtistMatchesTop is the production
+// "HEROIN / MAROON 5" scenario: iTunes Search returned the correct
+// track as its top hit, but Gemini was uncertain (single-letter
+// difference between "HEROIN" and "Heroine") and returned trackId=null.
+//
+// The hybrid fallback should adopt the top hit because its artist —
+// after normalization — matches the LLM-derived canonicalArtist.
+func TestEnrichHybrid_LLMNullButArtistMatchesTop(t *testing.T) {
+	itunesRaw := itunesResultsFixture(
+		map[string]interface{}{
+			"trackId":       float64(6763663512),
+			"trackName":     "Heroine",
+			"artistName":    "Maroon 5",
+			"artworkUrl100": "https://example.com/v/100x100bb.jpg",
+		},
+	)
+	verdict := map[string]interface{}{
+		"trackId":         nil,
+		"canonicalTitle":  "Heroine",
+		"canonicalArtist": "Maroon 5",
+	}
+	res := applyVerdictForTest(itunesRaw, verdict)
+	if res.ITunesTrackID != 6763663512 {
+		t.Errorf("expected hybrid fallback to set TrackID=6763663512, got %d", res.ITunesTrackID)
+	}
+	if res.ITunesURL != "https://music.apple.com/jp/song/6763663512" {
+		t.Errorf("ITunesURL = %q", res.ITunesURL)
+	}
+	if res.ArtworkURL != "https://example.com/v/600x600bb.jpg" {
+		t.Errorf("ArtworkURL = %q", res.ArtworkURL)
+	}
+}
+
+// TestEnrichHybrid_ArtistMismatchKeepsLLMNull confirms the safety
+// rail: if iTunes' top result is a completely different artist, the
+// fallback is rejected and we end up without an iTunes link.
+func TestEnrichHybrid_ArtistMismatchKeepsLLMNull(t *testing.T) {
+	itunesRaw := itunesResultsFixture(
+		map[string]interface{}{
+			"trackId":       float64(123),
+			"trackName":     "My Way",
+			"artistName":    "Calvin Harris", // unrelated
+			"artworkUrl100": "https://example.com/cal/100x100bb.jpg",
+		},
+	)
+	verdict := map[string]interface{}{
+		"trackId":         nil,
+		"canonicalTitle":  "If I Hadn't Got You",
+		"canonicalArtist": "Chris Braide", // does not match "Calvin Harris"
+	}
+	res := applyVerdictForTest(itunesRaw, verdict)
+	if res.ITunesTrackID != 0 {
+		t.Errorf("expected no fallback for artist mismatch, got TrackID=%d", res.ITunesTrackID)
+	}
+	if res.ITunesURL != "" {
+		t.Errorf("expected empty ITunesURL, got %q", res.ITunesURL)
+	}
+	if res.ArtworkURL != "" {
+		t.Errorf("expected empty ArtworkURL, got %q (suppress to keep parity with link)", res.ArtworkURL)
+	}
+}
+
+// TestEnrichHybrid_LLMPickedTrustsLLM ensures we still trust the LLM
+// when it does pick a trackId — even if a different result is at the
+// top of the iTunes list.
+func TestEnrichHybrid_LLMPickedTrustsLLM(t *testing.T) {
+	itunesRaw := itunesResultsFixture(
+		map[string]interface{}{
+			"trackId":       float64(111),
+			"trackName":     "Wrong Song",
+			"artistName":    "Wrong Artist",
+			"artworkUrl100": "https://wrong/100x100bb.jpg",
+		},
+		map[string]interface{}{
+			"trackId":       float64(222),
+			"trackName":     "Right Song",
+			"artistName":    "Right Artist",
+			"artworkUrl100": "https://right/100x100bb.jpg",
+		},
+	)
+	verdict := map[string]interface{}{
+		"trackId":         float64(222), // LLM picked second result
+		"canonicalTitle":  "Right Song",
+		"canonicalArtist": "Right Artist",
+	}
+	res := applyVerdictForTest(itunesRaw, verdict)
+	if res.ITunesTrackID != 222 {
+		t.Errorf("expected TrackID=222 (LLM choice), got %d", res.ITunesTrackID)
+	}
+	// Artwork should follow the LLM-picked track, not the top result.
+	if res.ArtworkURL != "https://right/600x600bb.jpg" {
+		t.Errorf("ArtworkURL = %q, expected to track the LLM-picked id", res.ArtworkURL)
+	}
+}
+
+// TestEnrichHybrid_ArtistTransliterationMatches verifies the
+// normalization layer collapses "Maroon 5" / "マルーン5" — but only
+// after ASCII full-width conversion; pure transliteration is NOT
+// covered by Normalize, so this must still rely on the LLM
+// canonicalArtist string carrying the same form as iTunes returns.
+func TestEnrichHybrid_ArtistTransliterationMatches(t *testing.T) {
+	// iTunes returns artistName in fullwidth digits "5" → "5"; the LLM
+	// canonical happens to be ASCII. Normalize folds NFKC so they match.
+	itunesRaw := itunesResultsFixture(
+		map[string]interface{}{
+			"trackId":       float64(999),
+			"artistName":    "MAROON 5", // from iTunes country=us perhaps
+			"artworkUrl100": "https://x/100x100bb.jpg",
+		},
+	)
+	verdict := map[string]interface{}{
+		"trackId":         nil,
+		"canonicalArtist": "Maroon 5",
+	}
+	res := applyVerdictForTest(itunesRaw, verdict)
+	if res.ITunesTrackID != 999 {
+		t.Errorf("expected fallback to recognize 'MAROON 5' == 'Maroon 5', got TrackID=%d", res.ITunesTrackID)
+	}
+}

--- a/insert_play_test.go
+++ b/insert_play_test.go
@@ -1,0 +1,237 @@
+package onairlogsync
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// helper for *time.Time literals.
+func ts(s string) *time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return &t
+}
+
+func TestBuildPlay(t *testing.T) {
+	at := ts("2026-05-08T11:11:54+09:00")
+	p := BuildPlay(at, "イデアが溢れて眠れない", "VAUNDY")
+	if p.Time != at {
+		t.Errorf("Play.Time pointer = %p, want %p", p.Time, at)
+	}
+	if !p.Time.Equal(*at) {
+		t.Errorf("Play.Time = %v, want %v", p.Time, at)
+	}
+	if p.RawTitle != "イデアが溢れて眠れない" {
+		t.Errorf("RawTitle = %q", p.RawTitle)
+	}
+	if p.RawArtist != "VAUNDY" {
+		t.Errorf("RawArtist = %q", p.RawArtist)
+	}
+	if p.SongID == "" {
+		t.Errorf("SongID empty")
+	}
+}
+
+func TestNewSongFromPlay(t *testing.T) {
+	at := ts("2026-05-08T11:11:54+09:00")
+	s := NewSongFromPlay(at, "イデアが溢れて眠れない", "VAUNDY")
+	if s.PlayCount != 1 {
+		t.Errorf("PlayCount = %d", s.PlayCount)
+	}
+	if !s.FirstAired.Equal(*at) || !s.LastAired.Equal(*at) {
+		t.Errorf("aired = (%v, %v), want both %v", s.FirstAired, s.LastAired, at)
+	}
+}
+
+func TestApplyPlay_newerAirTime(t *testing.T) {
+	// Existing lastAired is in the past; airTime is more recent.
+	existing := Song{
+		Title:      "Foo",
+		Artist:     "Bar",
+		FirstAired: ts("2020-01-01T00:00:00Z"),
+		LastAired:  ts("2026-05-03T05:28:17Z"),
+		PlayCount:  3,
+	}
+	at := ts("2026-05-08T02:11:54Z")
+	updated := ApplyPlay(existing, at)
+
+	if !updated.LastAired.Equal(*at) {
+		t.Errorf("LastAired = %v, want %v", updated.LastAired, at)
+	}
+	if !updated.FirstAired.Equal(*existing.FirstAired) {
+		t.Errorf("FirstAired changed: %v != %v", updated.FirstAired, existing.FirstAired)
+	}
+	if updated.PlayCount != 4 {
+		t.Errorf("PlayCount = %d, want 4", updated.PlayCount)
+	}
+	// Defensive: ApplyPlay must not mutate the original.
+	if !existing.LastAired.Equal(time.Date(2026, 5, 3, 5, 28, 17, 0, time.UTC)) {
+		t.Errorf("ApplyPlay mutated input.LastAired")
+	}
+	if existing.PlayCount != 3 {
+		t.Errorf("ApplyPlay mutated input.PlayCount")
+	}
+}
+
+func TestApplyPlay_olderAirTime(t *testing.T) {
+	// airTime is OLDER than existing.LastAired. lastAired should NOT
+	// move backwards. The new play is still counted.
+	existing := Song{
+		Title:      "Foo",
+		Artist:     "Bar",
+		FirstAired: ts("2020-01-01T00:00:00Z"),
+		LastAired:  ts("2026-05-08T02:11:54Z"),
+		PlayCount:  4,
+	}
+	at := ts("2026-05-03T05:28:17Z")
+	updated := ApplyPlay(existing, at)
+
+	if !updated.LastAired.Equal(*existing.LastAired) {
+		t.Errorf("LastAired = %v, want unchanged %v", updated.LastAired, existing.LastAired)
+	}
+	if updated.PlayCount != 5 {
+		t.Errorf("PlayCount = %d, want 5", updated.PlayCount)
+	}
+}
+
+func TestApplyPlay_olderThanFirstAired(t *testing.T) {
+	// airTime is older than firstAired (radio digging up older history).
+	existing := Song{
+		FirstAired: ts("2020-01-01T00:00:00Z"),
+		LastAired:  ts("2020-01-01T00:00:00Z"),
+		PlayCount:  1,
+	}
+	at := ts("2010-05-20T00:00:00Z")
+	updated := ApplyPlay(existing, at)
+
+	if !updated.FirstAired.Equal(*at) {
+		t.Errorf("FirstAired = %v, want %v", updated.FirstAired, at)
+	}
+	if !updated.LastAired.Equal(*existing.LastAired) {
+		t.Errorf("LastAired changed unexpectedly")
+	}
+	if updated.PlayCount != 2 {
+		t.Errorf("PlayCount = %d", updated.PlayCount)
+	}
+}
+
+// TestPublishedPlay_payloadFreshAirplay simulates Sync inserting today's
+// airplay for a song that already exists in Firestore. The resulting
+// PublishedPlay must carry today's airTime in BOTH play.time and
+// song.lastAired (because today > existing.lastAired).
+func TestPublishedPlay_payloadFreshAirplay(t *testing.T) {
+	existing := Song{
+		Title:      "イデアが溢れて眠れない",
+		Artist:     "VAUNDY",
+		FirstAired: ts("2026-04-27T14:19:37Z"),
+		LastAired:  ts("2026-05-03T05:28:17Z"),
+		PlayCount:  3,
+	}
+	at := ts("2026-05-08T02:11:54Z") // today's airplay UTC
+	pp := PublishedPlay{
+		Play: BuildPlay(at, "イデアが溢れて眠れない", "VAUNDY"),
+		Song: ApplyPlay(existing, at),
+	}
+
+	if !pp.Play.Time.Equal(*at) {
+		t.Fatalf("play.Time = %v, want %v", pp.Play.Time, at)
+	}
+	if !pp.Song.LastAired.Equal(*at) {
+		t.Fatalf("song.LastAired = %v, want %v", pp.Song.LastAired, at)
+	}
+
+	b, err := json.Marshal(pp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded PublishedPlay
+	if err := json.Unmarshal(b, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if !decoded.Play.Time.Equal(*at) {
+		t.Errorf("decoded play.Time = %v, want %v", decoded.Play.Time, at)
+	}
+	if !decoded.Song.LastAired.Equal(*at) {
+		t.Errorf("decoded song.LastAired = %v, want %v", decoded.Song.LastAired, at)
+	}
+}
+
+// TestPublishedPlay_payloadStaleAirplay covers the (suspicious in
+// production) case where airTime is OLDER than existing.LastAired.
+// The ASSERTION is: play.time MUST equal airTime (the value passed in),
+// and song.lastAired MUST equal the existing (newer) value, NOT airTime.
+//
+// This pins the contract that play.time and song.lastAired are
+// independent — diverging when the airTime is in the past.
+func TestPublishedPlay_payloadStaleAirplay(t *testing.T) {
+	existing := Song{
+		Title:      "イデアが溢れて眠れない",
+		Artist:     "VAUNDY",
+		FirstAired: ts("2026-04-27T14:19:37Z"),
+		LastAired:  ts("2026-05-08T02:11:54Z"),
+		PlayCount:  4,
+	}
+	at := ts("2026-05-03T05:28:17Z") // older than existing.LastAired
+	pp := PublishedPlay{
+		Play: BuildPlay(at, "イデアが溢れて眠れない", "VAUNDY"),
+		Song: ApplyPlay(existing, at),
+	}
+
+	if !pp.Play.Time.Equal(*at) {
+		t.Errorf("play.Time = %v, want %v (must equal airTime regardless of song state)",
+			pp.Play.Time, at)
+	}
+	if !pp.Song.LastAired.Equal(*existing.LastAired) {
+		t.Errorf("song.LastAired = %v, want %v (must NOT regress to airTime)",
+			pp.Song.LastAired, existing.LastAired)
+	}
+	if pp.Play.Time.Equal(*pp.Song.LastAired) {
+		t.Errorf("play.Time and song.LastAired ended up equal (%v) — production bug pattern",
+			pp.Play.Time)
+	}
+
+	// JSON round-trip — values must survive serialization unchanged.
+	b, err := json.Marshal(pp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded PublishedPlay
+	if err := json.Unmarshal(b, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if !decoded.Play.Time.Equal(*at) {
+		t.Errorf("after JSON round-trip play.Time = %v, want %v", decoded.Play.Time, at)
+	}
+	if !decoded.Song.LastAired.Equal(*existing.LastAired) {
+		t.Errorf("after JSON round-trip song.LastAired = %v, want %v",
+			decoded.Song.LastAired, existing.LastAired)
+	}
+}
+
+// TestPublishedPlay_pointerAliasingIsBenign ensures that ApplyPlay
+// re-using the airTime pointer for LastAired (via the conditional
+// assignment) does not cause play.Time and song.LastAired to share
+// fate even though they reference the same time.Time instance. Both
+// point to airTime, both serialize as airTime — no value drift.
+func TestPublishedPlay_pointerAliasingIsBenign(t *testing.T) {
+	existing := Song{
+		LastAired:  ts("2026-05-03T05:28:17Z"),
+		FirstAired: ts("2020-01-01T00:00:00Z"),
+		PlayCount:  3,
+	}
+	at := ts("2026-05-08T02:11:54Z")
+	pp := PublishedPlay{
+		Play: BuildPlay(at, "title", "artist"),
+		Song: ApplyPlay(existing, at),
+	}
+	if pp.Play.Time != pp.Song.LastAired {
+		t.Logf("note: pointers differ (Play.Time=%p, Song.LastAired=%p)", pp.Play.Time, pp.Song.LastAired)
+	}
+	// Both must report airTime regardless of pointer identity.
+	if !pp.Play.Time.Equal(*at) || !pp.Song.LastAired.Equal(*at) {
+		t.Errorf("expected both = airTime, got play.Time=%v song.LastAired=%v", pp.Play.Time, pp.Song.LastAired)
+	}
+}

--- a/insert_play_test.go
+++ b/insert_play_test.go
@@ -235,3 +235,97 @@ func TestPublishedPlay_pointerAliasingIsBenign(t *testing.T) {
 		t.Errorf("expected both = airTime, got play.Time=%v song.LastAired=%v", pp.Play.Time, pp.Song.LastAired)
 	}
 }
+
+// TestProduction_airTimeNewerThanLastAired pins the contract for the
+// scenario that broke in production: J-WAVE plays the song today
+// (airTime = today, JST), but the song's existing.LastAired in
+// Firestore is older (e.g. yesterday's catch-up imported May 3 entry).
+//
+// Expected: play.time AND song.lastAired both move to airTime.
+//
+// The Slack notification observed in production showed play.time =
+// existing.LastAired (= old) for this scenario, which contradicts the
+// pure-logic contract this test enforces.
+func TestProduction_airTimeNewerThanLastAired(t *testing.T) {
+	existing := Song{
+		Title:      "イデアが溢れて眠れない",
+		Artist:     "VAUNDY",
+		FirstAired: ts("2026-04-27T14:19:37Z"),
+		LastAired:  ts("2026-05-03T05:28:17Z"), // older
+		PlayCount:  3,
+	}
+	at := ts("2026-05-08T02:11:54Z") // today's airplay (newer)
+
+	pp := PublishedPlay{
+		Play: BuildPlay(at, "イデアが溢れて眠れない", "VAUNDY"),
+		Song: ApplyPlay(existing, at),
+	}
+
+	if !pp.Play.Time.Equal(*at) {
+		t.Errorf("play.Time = %v, want %v (airTime, today)", pp.Play.Time, at)
+	}
+	if !pp.Song.LastAired.Equal(*at) {
+		t.Errorf("song.LastAired = %v, want %v (must advance from %v to today)",
+			pp.Song.LastAired, at, existing.LastAired)
+	}
+	if pp.Song.PlayCount != 4 {
+		t.Errorf("playCount = %d, want 4", pp.Song.PlayCount)
+	}
+
+	// Round-trip the JSON the way Sync→Pub/Sub→Notify would.
+	b, _ := json.Marshal(pp)
+	var got PublishedPlay
+	_ = json.Unmarshal(b, &got)
+	if !got.Play.Time.Equal(*at) || !got.Song.LastAired.Equal(*at) {
+		t.Errorf("after JSON round-trip play.Time=%v song.LastAired=%v, want both %v",
+			got.Play.Time, got.Song.LastAired, at)
+	}
+	// Detect the production bug pattern (play.time matching the OLD
+	// existing.LastAired). If this triggers, the bug landed in pure
+	// logic — test it before chasing Firestore/HTTP layers.
+	if got.Play.Time.Equal(*existing.LastAired) && got.Song.LastAired.Equal(*existing.LastAired) {
+		t.Errorf("regression: play.time and song.lastAired both equal the stale existing.LastAired (%v)",
+			existing.LastAired)
+	}
+}
+
+// TestProduction_airTimeOlderThanLastAired covers the opposite of the
+// production scenario: the J-WAVE feed surfaces an older airplay (e.g.
+// catch-up scrape of an earlier date) for a song whose Firestore
+// LastAired already points at a more recent airing.
+//
+// Expected: play.time = airTime (the older time), song.lastAired
+// stays at existing (must not regress).
+func TestProduction_airTimeOlderThanLastAired(t *testing.T) {
+	existing := Song{
+		Title:      "イデアが溢れて眠れない",
+		Artist:     "VAUNDY",
+		FirstAired: ts("2026-04-27T14:19:37Z"),
+		LastAired:  ts("2026-05-08T02:11:54Z"), // newer
+		PlayCount:  4,
+	}
+	at := ts("2026-05-03T05:28:17Z") // older
+
+	pp := PublishedPlay{
+		Play: BuildPlay(at, "イデアが溢れて眠れない", "VAUNDY"),
+		Song: ApplyPlay(existing, at),
+	}
+
+	if !pp.Play.Time.Equal(*at) {
+		t.Errorf("play.Time = %v, want %v (airTime)", pp.Play.Time, at)
+	}
+	if !pp.Song.LastAired.Equal(*existing.LastAired) {
+		t.Errorf("song.LastAired = %v, want %v (must not regress)",
+			pp.Song.LastAired, existing.LastAired)
+	}
+	if pp.Song.PlayCount != 5 {
+		t.Errorf("playCount = %d, want 5", pp.Song.PlayCount)
+	}
+	// In this case, play.time and song.lastAired SHOULD differ because
+	// they are independent pieces of metadata.
+	if pp.Play.Time.Equal(*pp.Song.LastAired) {
+		t.Errorf("play.time and song.lastAired collapsed to the same value (%v); "+
+			"they should diverge when airTime is older than existing.LastAired",
+			pp.Play.Time)
+	}
+}

--- a/notify.go
+++ b/notify.go
@@ -15,6 +15,63 @@ func init() {
 	functions.CloudEvent("Notify", Notify)
 }
 
+// jstLocation returns Asia/Tokyo, falling back to UTC if the zone
+// database is unavailable (e.g. in a stripped-down container).
+func jstLocation() *time.Location {
+	loc, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		return time.UTC
+	}
+	return loc
+}
+
+// BuildSlackAttachment renders a Slack attachment for a single
+// PublishedPlay. Pure function — no side effects, suitable for tests.
+//
+// Title / artist prefer the canonical (enriched) values, falling back
+// to the raw display fields, then to the play's raw title/artist.
+// The footer always shows the JST-formatted airplay time so Slack's
+// own ts collapse cannot hide the time of day.
+func BuildSlackAttachment(item PublishedPlay, loc *time.Location) (slack.Attachment, bool) {
+	if item.Play.Time == nil {
+		return slack.Attachment{}, false
+	}
+	if loc == nil {
+		loc = time.UTC
+	}
+
+	song := item.Song
+	title := song.DisplayTitle()
+	artist := song.DisplayArtist()
+	if title == "" {
+		title = item.Play.RawTitle
+	}
+	if artist == "" {
+		artist = item.Play.RawArtist
+	}
+
+	t := item.Play.Time.In(loc)
+	timeStr := t.Format("2006/01/02 15:04")
+	fallback := fmt.Sprintf("%s %s / %s", timeStr, title, artist)
+	ts := item.Play.Time.Unix()
+
+	a := slack.Attachment{}
+	a.Fallback = &fallback
+	a.AuthorName = &artist
+	a.Title = &title
+	a.Footer = &timeStr
+	a.Timestamp = &ts
+	if song.ITunesURL != "" {
+		link := song.ITunesURL
+		a.TitleLink = &link
+	}
+	if song.ArtworkURL != "" {
+		art := song.ArtworkURL
+		a.ImageUrl = &art
+	}
+	return a, true
+}
+
 func Notify(ctx context.Context, e event.Event) error {
 	webhookUrl := mustGetenv("SLACK_WEBHOOK_URL")
 	app := NewApp(ctx)
@@ -30,45 +87,14 @@ func Notify(ctx context.Context, e event.Event) error {
 		return err
 	}
 
+	jst := jstLocation()
 	for _, item := range plays {
-		t := item.Play.Time
-		if t == nil {
+		attachment, ok := BuildSlackAttachment(item, jst)
+		if !ok {
 			continue
 		}
-		song := item.Song
-		title := song.DisplayTitle()
-		artist := song.DisplayArtist()
-		if title == "" {
-			title = item.Play.RawTitle
-		}
-		if artist == "" {
-			artist = item.Play.RawArtist
-		}
-		jst, err := time.LoadLocation("Asia/Tokyo")
-		if err != nil {
-			app.LogError(err)
-			jst = time.UTC
-		}
-		timeStr := t.In(jst).Format("2006/01/02 15:04")
-		fallback := fmt.Sprintf("%s %s / %s", timeStr, title, artist)
-		ts := t.Unix()
-
-		attachment1 := slack.Attachment{}
-		attachment1.Fallback = &fallback
-		attachment1.AuthorName = &artist
-		attachment1.Title = &title
-		attachment1.Footer = &timeStr
-		attachment1.Timestamp = &ts
-		if song.ITunesURL != "" {
-			link := song.ITunesURL
-			attachment1.TitleLink = &link
-		}
-		if song.ArtworkURL != "" {
-			art := song.ArtworkURL
-			attachment1.ImageUrl = &art
-		}
 		payload := slack.Payload{
-			Attachments: []slack.Attachment{attachment1},
+			Attachments: []slack.Attachment{attachment},
 		}
 		errors := slack.Send(webhookUrl, "", payload)
 		if len(errors) > 0 {

--- a/notify.go
+++ b/notify.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
@@ -81,6 +82,9 @@ func Notify(ctx context.Context, e event.Event) error {
 		app.LogError(err)
 		return err
 	}
+	log.Printf("notify: received pubsub data (%d bytes): %s",
+		len(msg.Message.Data), string(msg.Message.Data))
+
 	var plays []PublishedPlay
 	if err := json.Unmarshal(msg.Message.Data, &plays); err != nil {
 		app.LogError(err)
@@ -88,13 +92,17 @@ func Notify(ctx context.Context, e event.Event) error {
 	}
 
 	jst := jstLocation()
-	for _, item := range plays {
+	for i, item := range plays {
 		attachment, ok := BuildSlackAttachment(item, jst)
 		if !ok {
+			log.Printf("notify[%d]: skipped (Play.Time nil) raw=%+v", i, item)
 			continue
 		}
 		payload := slack.Payload{
 			Attachments: []slack.Attachment{attachment},
+		}
+		if b, err := json.Marshal(payload); err == nil {
+			log.Printf("notify[%d]: slack payload: %s", i, string(b))
 		}
 		errors := slack.Send(webhookUrl, "", payload)
 		if len(errors) > 0 {

--- a/notify.go
+++ b/notify.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
 	"github.com/ashwanthkumar/slack-go-webhook"
@@ -43,7 +44,12 @@ func Notify(ctx context.Context, e event.Event) error {
 		if artist == "" {
 			artist = item.Play.RawArtist
 		}
-		timeStr := t.Format("2006/01/02 15:04")
+		jst, err := time.LoadLocation("Asia/Tokyo")
+		if err != nil {
+			app.LogError(err)
+			jst = time.UTC
+		}
+		timeStr := t.In(jst).Format("2006/01/02 15:04")
 		fallback := fmt.Sprintf("%s %s / %s", timeStr, title, artist)
 		ts := t.Unix()
 
@@ -51,11 +57,14 @@ func Notify(ctx context.Context, e event.Event) error {
 		attachment1.Fallback = &fallback
 		attachment1.AuthorName = &artist
 		attachment1.Title = &title
+		attachment1.Footer = &timeStr
 		attachment1.Timestamp = &ts
-		if link := song.ITunesURL(); link != "" {
+		if song.ITunesURL != "" {
+			link := song.ITunesURL
 			attachment1.TitleLink = &link
 		}
-		if art := song.ArtworkURL(); art != "" {
+		if song.ArtworkURL != "" {
+			art := song.ArtworkURL
 			attachment1.ImageUrl = &art
 		}
 		payload := slack.Payload{

--- a/notify_test.go
+++ b/notify_test.go
@@ -1,0 +1,202 @@
+package onairlogsync
+
+import (
+	"testing"
+)
+
+func deref(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}
+
+func derefInt(p *int64) int64 {
+	if p == nil {
+		return 0
+	}
+	return *p
+}
+
+func TestBuildSlackAttachment_nilTime(t *testing.T) {
+	pp := PublishedPlay{
+		Play: Play{Time: nil, RawTitle: "x", RawArtist: "y"},
+		Song: Song{},
+	}
+	_, ok := BuildSlackAttachment(pp, jstLocation())
+	if ok {
+		t.Errorf("expected ok=false for nil Play.Time")
+	}
+}
+
+func TestBuildSlackAttachment_enrichedSong(t *testing.T) {
+	at := ts("2026-05-08T01:45:56Z") // = JST 10:45:56
+	pp := PublishedPlay{
+		Play: Play{
+			Time:      at,
+			SongID:    "abc",
+			RawTitle:  "YOU MIGHT THINK",
+			RawArtist: "CARS",
+		},
+		Song: Song{
+			Title:           "YOU MIGHT THINK",
+			Artist:          "CARS",
+			CanonicalTitle:  "You Might Think",
+			CanonicalArtist: "The Cars",
+			ITunesTrackID:   1088528668,
+			ITunesURL:       "https://music.apple.com/jp/song/1088528668",
+			ArtworkURL:      "https://example.com/art.jpg",
+		},
+	}
+	a, ok := BuildSlackAttachment(pp, jstLocation())
+	if !ok {
+		t.Fatal("ok=false unexpected")
+	}
+	if got := deref(a.Title); got != "You Might Think" {
+		t.Errorf("Title = %q, want canonical 'You Might Think'", got)
+	}
+	if got := deref(a.AuthorName); got != "The Cars" {
+		t.Errorf("AuthorName = %q, want canonical 'The Cars'", got)
+	}
+	if got := deref(a.TitleLink); got != "https://music.apple.com/jp/song/1088528668" {
+		t.Errorf("TitleLink = %q", got)
+	}
+	if got := deref(a.ImageUrl); got != "https://example.com/art.jpg" {
+		t.Errorf("ImageUrl = %q", got)
+	}
+	if got := deref(a.Footer); got != "2026/05/08 10:45" {
+		t.Errorf("Footer = %q, want JST-formatted '2026/05/08 10:45'", got)
+	}
+	if got := derefInt(a.Timestamp); got != at.Unix() {
+		t.Errorf("Timestamp = %d, want %d", got, at.Unix())
+	}
+	if got := deref(a.Fallback); got != "2026/05/08 10:45 You Might Think / The Cars" {
+		t.Errorf("Fallback = %q", got)
+	}
+}
+
+func TestBuildSlackAttachment_unenrichedSong(t *testing.T) {
+	// No canonical fields, no iTunes data. Should fall back to raw
+	// display values from the Song struct, no link, no artwork.
+	at := ts("2026-05-08T01:45:56Z")
+	pp := PublishedPlay{
+		Play: Play{
+			Time:      at,
+			RawTitle:  "RAW TITLE",
+			RawArtist: "RAW ARTIST",
+		},
+		Song: Song{
+			Title:  "RAW TITLE",
+			Artist: "RAW ARTIST",
+		},
+	}
+	a, ok := BuildSlackAttachment(pp, jstLocation())
+	if !ok {
+		t.Fatal("ok=false unexpected")
+	}
+	if got := deref(a.Title); got != "RAW TITLE" {
+		t.Errorf("Title = %q, want raw 'RAW TITLE'", got)
+	}
+	if got := deref(a.AuthorName); got != "RAW ARTIST" {
+		t.Errorf("AuthorName = %q", got)
+	}
+	if a.TitleLink != nil {
+		t.Errorf("TitleLink = %q, want nil", deref(a.TitleLink))
+	}
+	if a.ImageUrl != nil {
+		t.Errorf("ImageUrl = %q, want nil", deref(a.ImageUrl))
+	}
+}
+
+func TestBuildSlackAttachment_emptySongFallsBackToRawPlay(t *testing.T) {
+	// Song has no fields populated (e.g. lookup failure). Slack
+	// attachment should still render using the Play's raw fields.
+	at := ts("2026-05-08T01:45:56Z")
+	pp := PublishedPlay{
+		Play: Play{
+			Time:      at,
+			RawTitle:  "FALLBACK TITLE",
+			RawArtist: "FALLBACK ARTIST",
+		},
+		Song: Song{}, // empty
+	}
+	a, ok := BuildSlackAttachment(pp, jstLocation())
+	if !ok {
+		t.Fatal("ok=false unexpected")
+	}
+	if got := deref(a.Title); got != "FALLBACK TITLE" {
+		t.Errorf("Title = %q", got)
+	}
+	if got := deref(a.AuthorName); got != "FALLBACK ARTIST" {
+		t.Errorf("AuthorName = %q", got)
+	}
+}
+
+// TestBuildSlackAttachment_footerUsesPlayTime ensures the rendered
+// timestamp comes from Play.Time, never from Song.LastAired (the
+// latter can be older than the airplay during enrichment edge cases).
+func TestBuildSlackAttachment_footerUsesPlayTime(t *testing.T) {
+	playAt := ts("2026-05-08T02:11:54Z")     // today
+	songLast := ts("2026-05-03T05:28:17Z")   // older
+	pp := PublishedPlay{
+		Play: Play{Time: playAt, RawTitle: "T", RawArtist: "A"},
+		Song: Song{Title: "T", Artist: "A", LastAired: songLast},
+	}
+	a, ok := BuildSlackAttachment(pp, jstLocation())
+	if !ok {
+		t.Fatal("ok=false")
+	}
+	wantFooter := "2026/05/08 11:11"
+	if got := deref(a.Footer); got != wantFooter {
+		t.Errorf("footer = %q, want %q (must reflect Play.Time, not Song.LastAired)", got, wantFooter)
+	}
+	if got := derefInt(a.Timestamp); got != playAt.Unix() {
+		t.Errorf("ts = %d, want %d (Play.Time)", got, playAt.Unix())
+	}
+}
+
+// TestBuildSlackAttachment_artworkButNoLink mirrors the production
+// case where iTunes Search returned a result (so artwork was
+// extracted) but Gemini said no match (so no trackId / URL). The
+// attachment should reflect that asymmetry — it is still rendered,
+// just without a clickable title.
+func TestBuildSlackAttachment_artworkButNoLink(t *testing.T) {
+	at := ts("2026-05-08T02:52:00Z")
+	pp := PublishedPlay{
+		Play: Play{Time: at, RawTitle: "HEROIN", RawArtist: "MAROON 5"},
+		Song: Song{
+			Title:           "HEROIN",
+			Artist:          "MAROON 5",
+			CanonicalTitle:  "Heroine",
+			CanonicalArtist: "Maroon 5",
+			ArtworkURL:      "https://example.com/heroine.jpg",
+			ITunesURL:       "", // no link
+		},
+	}
+	a, ok := BuildSlackAttachment(pp, jstLocation())
+	if !ok {
+		t.Fatal("ok=false")
+	}
+	if a.ImageUrl == nil {
+		t.Errorf("expected ImageUrl set when ArtworkURL is non-empty")
+	}
+	if a.TitleLink != nil {
+		t.Errorf("TitleLink = %q, expected nil when ITunesURL is empty", deref(a.TitleLink))
+	}
+}
+
+func TestBuildSlackAttachment_jstFormatting(t *testing.T) {
+	// JST midnight from a UTC of 15:00 the previous day.
+	at := ts("2026-05-07T15:00:00Z") // = JST 2026-05-08 00:00
+	pp := PublishedPlay{
+		Play: Play{Time: at, RawTitle: "x", RawArtist: "y"},
+		Song: Song{Title: "x", Artist: "y"},
+	}
+	a, ok := BuildSlackAttachment(pp, jstLocation())
+	if !ok {
+		t.Fatal("ok=false")
+	}
+	if got := deref(a.Footer); got != "2026/05/08 00:00" {
+		t.Errorf("footer = %q, want '2026/05/08 00:00'", got)
+	}
+}

--- a/song.go
+++ b/song.go
@@ -23,8 +23,14 @@ type Song struct {
 	CanonicalTitle  string                 `firestore:"canonicalTitle,omitempty" json:"canonicalTitle,omitempty"`
 	CanonicalArtist string                 `firestore:"canonicalArtist,omitempty" json:"canonicalArtist,omitempty"`
 	CanonicalKey    string                 `firestore:"canonicalKey,omitempty" json:"canonicalKey,omitempty"`
-	ITunesResponse  map[string]interface{} `firestore:"itunesResponse,omitempty" json:"-"`
-	LLMResponse     map[string]interface{} `firestore:"llmResponse,omitempty" json:"-"`
+	// Pre-computed for downstream consumers (Notify, API) so they
+	// don't have to dig through ITunesResponse.
+	ArtworkURL  string                 `firestore:"artworkUrl,omitempty" json:"artworkUrl,omitempty"`
+	ITunesURL   string                 `firestore:"itunesUrl,omitempty" json:"itunesUrl,omitempty"`
+	// Raw archives — Firestore-only, intentionally excluded from JSON
+	// to keep Pub/Sub payloads small.
+	ITunesResponse map[string]interface{} `firestore:"itunesResponse,omitempty" json:"-"`
+	LLMResponse    map[string]interface{} `firestore:"llmResponse,omitempty" json:"-"`
 }
 
 // Play is a single airplay event and references a Song by ID.
@@ -58,23 +64,22 @@ func (s *Song) DisplayArtist() string {
 	return s.Artist
 }
 
-// ITunesURL returns the music.apple.com URL for the verified track,
-// or an empty string when the song has no iTunes match.
-func (s *Song) ITunesURL() string {
-	if s == nil || s.ITunesTrackID == 0 {
+// BuildITunesURL is the music.apple.com URL for a verified iTunes
+// track id, or an empty string when there is no match.
+func BuildITunesURL(trackID int64) string {
+	if trackID == 0 {
 		return ""
 	}
-	return fmt.Sprintf("https://music.apple.com/jp/song/%d", s.ITunesTrackID)
+	return fmt.Sprintf("https://music.apple.com/jp/song/%d", trackID)
 }
 
-// ArtworkURL extracts the cover art URL from the archived iTunes
-// response and upscales it to 600x600. Returns an empty string when
-// no artwork is available.
-func (s *Song) ArtworkURL() string {
-	if s == nil || s.ITunesResponse == nil {
+// ExtractArtworkURL pulls the 600x600 cover art URL out of an iTunes
+// search result map (the top hit). Returns "" when unavailable.
+func ExtractArtworkURL(itunes map[string]interface{}) string {
+	if itunes == nil {
 		return ""
 	}
-	results, _ := s.ITunesResponse["results"].([]interface{})
+	results, _ := itunes["results"].([]interface{})
 	if len(results) == 0 {
 		return ""
 	}

--- a/song_test.go
+++ b/song_test.go
@@ -1,0 +1,175 @@
+package onairlogsync
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSongJSONIncludesEnrichmentURLs(t *testing.T) {
+	// Regression: Slack notifications were missing artwork because the
+	// pre-computed URLs were not flowing through the Pub/Sub payload.
+	// They must round-trip via JSON so Notify can read them.
+	now := time.Now().UTC()
+	in := Song{
+		Title:           "YOU MIGHT THINK",
+		Artist:          "CARS",
+		PlayCount:       5,
+		FirstAired:      &now,
+		LastAired:       &now,
+		EnrichedAt:      &now,
+		ITunesTrackID:   1088528668,
+		CanonicalTitle:  "You Might Think",
+		CanonicalArtist: "The Cars",
+		CanonicalKey:    "itunes:1088528668",
+		ArtworkURL:      "https://example.com/artwork.jpg",
+		ITunesURL:       "https://music.apple.com/jp/song/1088528668",
+		ITunesResponse: map[string]interface{}{
+			"resultCount": 1,
+			"results":     []interface{}{},
+		},
+	}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	js := string(b)
+
+	want := []string{`"artworkUrl":"https://example.com/artwork.jpg"`,
+		`"itunesUrl":"https://music.apple.com/jp/song/1088528668"`,
+		`"canonicalTitle":"You Might Think"`,
+		`"canonicalArtist":"The Cars"`,
+		`"itunesTrackId":1088528668`}
+	for _, w := range want {
+		if !strings.Contains(js, w) {
+			t.Errorf("expected JSON to contain %s, got: %s", w, js)
+		}
+	}
+
+	// ITunesResponse / LLMResponse are intentionally excluded from JSON.
+	for _, w := range []string{`itunesResponse`, `llmResponse`} {
+		if strings.Contains(js, w) {
+			t.Errorf("expected JSON to omit %s, got: %s", w, js)
+		}
+	}
+
+	var out Song
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.ArtworkURL != in.ArtworkURL {
+		t.Errorf("ArtworkURL not preserved: %q vs %q", out.ArtworkURL, in.ArtworkURL)
+	}
+	if out.ITunesURL != in.ITunesURL {
+		t.Errorf("ITunesURL not preserved: %q vs %q", out.ITunesURL, in.ITunesURL)
+	}
+	if out.CanonicalTitle != in.CanonicalTitle || out.CanonicalArtist != in.CanonicalArtist {
+		t.Errorf("canonical not preserved: %+v", out)
+	}
+	if out.ITunesTrackID != in.ITunesTrackID {
+		t.Errorf("trackId not preserved: %d vs %d", out.ITunesTrackID, in.ITunesTrackID)
+	}
+}
+
+func TestPublishedPlayRoundTrip(t *testing.T) {
+	// The full Pub/Sub payload Sync emits and Notify consumes.
+	now := time.Now().UTC()
+	in := []PublishedPlay{{
+		Play: Play{
+			SongID:    "abc",
+			Time:      &now,
+			RawTitle:  "YOU MIGHT THINK",
+			RawArtist: "CARS",
+		},
+		Song: Song{
+			Title:           "YOU MIGHT THINK",
+			Artist:          "CARS",
+			CanonicalTitle:  "You Might Think",
+			CanonicalArtist: "The Cars",
+			ArtworkURL:      "https://example.com/art.jpg",
+			ITunesURL:       "https://music.apple.com/jp/song/1",
+			ITunesTrackID:   1,
+		},
+	}}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out []PublishedPlay
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("len = %d", len(out))
+	}
+	got := out[0]
+	if got.Song.ArtworkURL != "https://example.com/art.jpg" {
+		t.Errorf("ArtworkURL lost in round-trip: %q", got.Song.ArtworkURL)
+	}
+	if got.Song.ITunesURL != "https://music.apple.com/jp/song/1" {
+		t.Errorf("ITunesURL lost in round-trip: %q", got.Song.ITunesURL)
+	}
+	if got.Play.RawTitle != "YOU MIGHT THINK" {
+		t.Errorf("RawTitle lost: %q", got.Play.RawTitle)
+	}
+}
+
+func TestDisplayTitleArtist(t *testing.T) {
+	cases := []struct {
+		s              Song
+		wantTitle      string
+		wantArtist     string
+		descr          string
+	}{
+		{Song{Title: "RAW TITLE", Artist: "RAW ARTIST"}, "RAW TITLE", "RAW ARTIST", "no canonical"},
+		{Song{Title: "RAW", Artist: "RAW", CanonicalTitle: "Canonical T", CanonicalArtist: "Canonical A"}, "Canonical T", "Canonical A", "both canonical"},
+		{Song{Title: "RAW", Artist: "RAW", CanonicalTitle: "Canonical T"}, "Canonical T", "RAW", "title canonical only"},
+		{Song{Title: "RAW", Artist: "RAW", CanonicalArtist: "Canonical A"}, "RAW", "Canonical A", "artist canonical only"},
+	}
+	for _, c := range cases {
+		if got := c.s.DisplayTitle(); got != c.wantTitle {
+			t.Errorf("[%s] DisplayTitle = %q, want %q", c.descr, got, c.wantTitle)
+		}
+		if got := c.s.DisplayArtist(); got != c.wantArtist {
+			t.Errorf("[%s] DisplayArtist = %q, want %q", c.descr, got, c.wantArtist)
+		}
+	}
+}
+
+func TestBuildITunesURL(t *testing.T) {
+	if got := BuildITunesURL(0); got != "" {
+		t.Errorf("expected empty for trackID=0, got %q", got)
+	}
+	if got := BuildITunesURL(12345); got != "https://music.apple.com/jp/song/12345" {
+		t.Errorf("unexpected: %q", got)
+	}
+}
+
+func TestExtractArtworkURL(t *testing.T) {
+	cases := []struct {
+		in   map[string]interface{}
+		want string
+	}{
+		{nil, ""},
+		{map[string]interface{}{}, ""},
+		{map[string]interface{}{"results": []interface{}{}}, ""},
+		{
+			map[string]interface{}{"results": []interface{}{
+				map[string]interface{}{"artworkUrl100": "https://x/100x100bb.jpg"},
+			}},
+			"https://x/600x600bb.jpg",
+		},
+		{
+			map[string]interface{}{"results": []interface{}{
+				map[string]interface{}{}, // no artworkUrl100
+			}},
+			"",
+		},
+	}
+	for _, c := range cases {
+		if got := ExtractArtworkURL(c.in); got != c.want {
+			t.Errorf("ExtractArtworkURL(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
本番で「Slack 通知の play.time が古い値 (song.lastAired と同値)」になる現象を調査するため、`InsertPlay` の純粋ロジック部分を抽出して単体テスト可能にしました。

## 抽出した関数

- \`BuildPlay(airTime, rawTitle, rawArtist) Play\`
- \`NewSongFromPlay(airTime, rawTitle, rawArtist) Song\`
- \`ApplyPlay(existing Song, airTime) Song\` — Pure (mutate しない、Firestore 不要)

\`InsertPlay\` のトランザクション内ロジックを上記 helper に置き換え。挙動は同じ。

## 追加したテスト

| テスト | airTime | existing.LastAired | 期待 play.time | 期待 song.lastAired |
|---|---|---|---|---|
| \`TestProduction_airTimeNewerThanLastAired\` | 今日 (May 8) | 古い (May 3) | 今日 | 今日 (更新) |
| \`TestProduction_airTimeOlderThanLastAired\` | 古い (May 3) | 今日 (May 8) | 古い | 今日 (退行しない) |

両方の方向に加え、\`BuildPlay\` / \`ApplyPlay\` / JSON ラウンドトリップを単体検証。**全 10 ケース PASS**。

## 結論 (現状)

純粋ロジック層では仕様通り動作する。本番で観測される「play.time = song.lastAired = 古い値」のパターンは、この層を経由した結果としては再現しない。バグの原因はより外側にある:

- \`ParseTime\` がスクレイプ HTML から古い時刻を取得している
- \`playRef.Create\` の AlreadyExists 検知が機能していない (Firestore SDK 挙動)
- 何らかの並行実行 / race